### PR TITLE
feat(v2): opening-window anti-snipe protection

### DIFF
--- a/contractsV2/ANTISNIPE.md
+++ b/contractsV2/ANTISNIPE.md
@@ -1,0 +1,179 @@
+# Opening-window protection for pons v2
+
+Branch: `features/enhance-antisnip`
+
+## Why
+
+Every protection in v2 today works in the dimension of **quantity or structure** —
+`reservedTokens` caps what the curve will ever sell, the whole supply mints to the
+curve so there is no pool to snipe at block zero, `_beforeInitialize` stops anyone
+pre-initializing the graduated PoolKey. None of them work in the dimension of
+**time**. In the first second of a launch the curve cannot tell a listener reacting
+to `TokenLaunched` from a human who opened the page.
+
+Robinhood Chain sequences first-come-first-served behind a single sequencer with no
+public mempool, so classical front-running is impossible — but latency racing is
+wide open, and the contestable edge is milliseconds.
+
+Note that v1's `restrictionEndBlock` approach does not transfer. At ~10 blocks per
+second, v1's two-block window is roughly **200 milliseconds**. Any temporal
+protection here has to be measured in wall-clock time.
+
+## What this branch adds
+
+### Layer 1 — decaying opening buy tax
+
+`PonsV2BondingCurve` gains four immutables (`launchedAt`, `snipeTaxStartBps`,
+`snipeTaxWindow`, `snipeTaxHalfLife`) and one view, `currentSnipeTaxBps(address)`.
+The levy applies to buys only, halves every `halfLife` seconds, and reaches zero at
+`window`. It is charged on the quote leg exactly like `feeBps`, before the input
+reaches the pricing reserve.
+
+`startBps == 0` disables it and reproduces the previous behaviour byte for byte,
+so existing launch configs stay expressible.
+
+**Resolution is whole seconds, deliberately.** `block.timestamp` is the only clock
+available: on an Arbitrum Orbit chain `block.number` approximates the *L1* block
+number and cannot measure L2 time. Every block inside the same second sees the same
+tax. That is the intended behaviour rather than a limitation — a bot's advantage
+over a human is sub-second, so a one-second floor removes it wholesale. Linear
+interpolation between halvings is implemented and takes effect whenever
+`halfLife > 1`.
+
+Example, `startBps = 9800`, `halfLife = 1`, `window = 8`:
+
+| t (s) | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|---|---|---|---|---|---|---|---|---|---|
+| bps | 9800 | 4900 | 2450 | 1225 | 612 | 306 | 153 | 76 | 0 |
+
+Gentler, `startBps = 5000`, `halfLife = 3`, `window = 12`:
+
+| t (s) | 0 | 1 | 2 | 3 | 6 | 9 | 12 |
+|---|---|---|---|---|---|---|---|
+| bps | 5000 | 4167 | 3334 | 2500 | 1250 | 625 | 0 |
+
+Four things this had to get right:
+
+1. **Keyed on `recipient`, not `msg.sender`.** Keying on the caller would let any
+   router — including one a sniper deploys — be exempted once and then resell entry
+   to the window.
+2. **Excluded from `MAX_TOTAL_TRADE_FEE_BPS`.** That 20% ceiling protects traders
+   from a creator's standing rake for the life of the launch. This levy is transient
+   and expires by itself. Folding them together would either cap the opening tax
+   where a bot would happily pay it, or raise the standing-rake ceiling to 99%.
+   Separate risks, separate limits — `MAX_SNIPE_TAX_START_BPS`.
+3. **Clamped-fill gross-up denominator.** `buy()` grosses a clamped fill back up by
+   `BASIS_POINTS - feeBps - creatorTaxBps - snipeBps`. The curve's constructor
+   enforces `MIN_BUYER_SHARE_BPS = 100`, so the denominator can never approach zero
+   where the ceil-rounding would blow up, and a buyer always nets at least 1%.
+4. **Routed through the existing fee split.** The levy joins the base fee in
+   `_accrueFees`, so it flows through protocol / buyback / creator untouched. No new
+   distribution path means no new surface for it to be diverted through. `CurveBuy.fee`
+   reports the combined amount; `SnipeTaxCharged` lets an indexer decompose it without
+   a second ABI for `CurveBuy`.
+
+One behavioural change beyond the levy: `buy()` now reverts `ZeroAmount` when
+`tokensOut == 0`. Reachable for dust inside the window, where the levy consumes the
+whole input before it reaches the curve. Refusing is strictly safer than settling —
+nobody is denied a fill they wanted, and the caller keeps their funds.
+
+### Layer 2 — exemptions
+
+`initialize` becomes `initialize(token, launcher, address[] snipeTaxExemptions)`,
+still `onlyFactory`, still once. The launcher and the creator fee recipient are
+excused unconditionally; the creator's own list is capped at
+`MAX_SNIPE_TAX_EXEMPTIONS = 32`. Duplicates and the zero address are skipped rather
+than rejected, since the list is assembled from three sources that do not know about
+each other and a cosmetic overlap should not fail a valid launch.
+
+**There is no setter.** An exemption granted after a launch is live would wave an
+address through a window every other buyer paid to cross.
+
+### Layer 3 — `PonsV2LaunchRouter`
+
+Layer 1 makes a creator's own opening buy prohibitive if it lands as a separate
+transaction, since nothing distinguishes it from a bot's. The router closes the
+window for the one case that is provably not a race: the buy atomic with the launch,
+which cannot have observed it.
+
+A separate contract purely for bytecode budget (see below). It needs
+`setTrustedRouter(router, true)` on the factory. That trust lets it attribute a
+launch to its caller; it does **not** let it launch for someone who could not launch
+themselves — `launchTokenFor` still gates the named launcher through `canLaunch`.
+Without that, the whitelist would be defeated by routing through a whitelisted
+contract.
+
+The router exempts the *recipient*, not itself, which is what makes the exemption
+non-transferable.
+
+### Supporting changes
+
+- `LaunchConfig` gains a `SnipeTaxTerms snipeTax` field, validated in
+  `_validateLaunchConfig` and folded into `_economicsDigest`, so a creator's
+  `expectedEconomics` pin now covers the window terms too. **This changes the
+  digest preimage from ten values to thirteen** — any off-chain code computing it
+  must be updated alongside.
+- `canLaunch(address)` exposed as a view, closing a gap the docs already assumed.
+- `trustedRouters` mapping plus `setTrustedRouter`, owner-gated.
+- `launchToken(params, id, pairToken)` keeps its exact signature and behaviour.
+  New work goes through `launchTokenFor(params, id, pairToken, launcher, exemptions)`,
+  where `launcher == address(0)` means the caller.
+
+## Bytecode budget
+
+`PonsV2LaunchFactory` was the binding constraint throughout. Measured with
+solc 0.8.28, `--via-ir --optimize --optimize-runs 200`:
+
+| Contract | Before | After |
+|---|---|---|
+| PonsV2LaunchFactory | 22757 | **24267** / 24576 |
+| PonsV2BondingCurve | — | 10448 |
+| PonsV2LaunchRouter | — | 3247 |
+
+309 bytes of headroom. The first draft carried three launch entry points and
+assembled the exemption array in the factory, and came out at 24744 — over the
+limit. Collapsing to two entry points (one full `TokenParams` calldata decode is
+expensive) and moving exemption assembly into the curve recovered ~480 bytes.
+
+**Anything further added to the factory needs a size check first.**
+
+## Not done, deliberately
+
+**Per-wallet cap during the window.** It is trivially defeated by splitting wallets
+on a chain with no identity, and enforcing it means making `buy()` revert — which
+destroys the "partial fill never fails" property that is currently v2's most elegant
+anti-grief protection. A tax cannot be wallet-split because it is charged per unit of
+capital, not per address.
+
+**CREATE2 launch addresses.** Worth doing, but not here and not first. A predictable
+curve address lets a sniper prepare calldata and approvals *before* the launch
+transaction lands; today's unpredictable addresses are an accidental protection. Land
+CREATE2 only after this window is live, or you weaken the position before replacing it.
+
+## Tests still to write
+
+- `currentSnipeTaxBps` monotonically decreasing; exactly zero at `launchedAt + window`
+- levy never causes `buy()` to revert for any `quoteIn` that would otherwise fill
+- worst case combined: clamped fill + max levy + max creator tax, checking gross-up rounding
+- exempt address pays zero at t=0; non-exempt recipient behind an exempt caller does not
+- fuzz `spent + refund == received` with the levy active
+- **graduation invariant**: with the levy at maximum, `reservedTokens` and the seeded
+  pool price are identical to a launch without it. The levy is taken off the input
+  before pricing, so it never enters the pricing reserve — this asserts that
+- fee split proportions unchanged; the levy only changes magnitude
+- router: launch + buy atomic, recipient exempt, native and ERC-20 quote paths,
+  clamped-fill refund forwarded to the caller, allowance cleared
+- `launchTokenFor` from an untrusted caller reverts; from a trusted router with a
+  non-whitelisted launcher reverts
+- regression: `_beforeInitialize` still rejects non-factory callers
+
+## Open questions for review
+
+1. A 98% levy at t=0 means someone who buys accidentally at t=0.2s loses nearly
+   everything. The mitigation is UI, not contract: show the live rate and gate the
+   buy button during the window. If the UI is not ready, lower `startBps` — 95%
+   with a shorter half-life deters almost as well with a far more forgiving tail.
+2. `MAX_SNIPE_TAX_WINDOW` is set to 60 seconds. Past a minute this stops being
+   anti-latency and becomes a standing tax on anyone without advance notice.
+3. The levy flows through the buyback split, meaning a heavily sniped launch funds
+   a larger PONS buyback. Intended, but worth stating out loud before mainnet.

--- a/contractsV2/src/v2/PonsV2BondingCurve.sol
+++ b/contractsV2/src/v2/PonsV2BondingCurve.sol
@@ -8,7 +8,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {PonsV2BondingCurveMath} from "./libraries/PonsV2BondingCurveMath.sol";
 import {PonsV2BuybackVault} from "./PonsV2BuybackVault.sol";
 import {PonsV2LauncherToken} from "./PonsV2LauncherToken.sol";
-import {FeePolicySnapshot, IPonsV2FeeEscrow, IPonsV2FeePolicy} from "./interfaces/ILaunchpadV2.sol";
+import {FeePolicySnapshot, IPonsV2FeeEscrow, IPonsV2FeePolicy, SnipeTaxTerms} from "./interfaces/ILaunchpadV2.sol";
 import {IPonsV2LaunchFactoryGraduation} from "./interfaces/ILaunchpadV2Graduation.sol";
 
 /**
@@ -33,6 +33,20 @@ contract PonsV2BondingCurve is ReentrancyGuard {
 
     uint256 private constant BASIS_POINTS = 10_000;
     uint256 private constant MAX_TOTAL_TRADE_FEE_BPS = 2_000; // 20%
+    // The opening tax is deliberately outside MAX_TOTAL_TRADE_FEE_BPS. That
+    // ceiling protects traders from a creator's standing rake for the life of
+    // the launch; this one is a transient anti-latency measure that expires on
+    // its own within seconds. Folding the two together would either cap the
+    // opening tax at a level a bot would happily pay, or raise the standing
+    // rake ceiling to 99%. They are separate risks and get separate limits.
+    uint256 private constant MAX_SNIPE_TAX_START_BPS = 9_900; // 99%
+    // Whatever the combined legs come to, a buyer keeps at least this share of
+    // their input. It is what stops the clamped-fill gross-up denominator from
+    // approaching zero, where the ceil-rounding would blow up.
+    uint256 private constant MIN_BUYER_SHARE_BPS = 100; // 1%
+    // Written in a single launch transaction and never extended, so the bound
+    // is what keeps the launch fee from becoming a gas-griefing surface.
+    uint256 private constant MAX_SNIPE_TAX_EXEMPTIONS = 32;
 
     error CurveGraduated();
     error ZeroAmount();
@@ -51,6 +65,8 @@ contract PonsV2BondingCurve is ReentrancyGuard {
     error MinimumOutputRequired();
     error NativeValueMismatch(uint256 supplied, uint256 expected);
     error UnexpectedNativeValue();
+    error InvalidSnipeTaxTerms();
+    error ExemptionListTooLong();
 
     // `fee` and `tax` are reported separately because they fund different
     // parties: the fee splits across protocol, buyback and creator, while the
@@ -75,6 +91,12 @@ contract PonsV2BondingCurve is ReentrancyGuard {
     event CreatorFeeRecipientUpdated(address indexed previousRecipient, address indexed newRecipient);
     event BuybackEnabledUpdated(bool enabled);
     event AutoGraduationFailed(address indexed token, uint256 gasRemaining);
+    // Emitted alongside CurveBuy, never instead of it. CurveBuy's `fee` field
+    // reports the combined amount routed through the fee split so that field
+    // keeps meaning "quote the protocol took"; this event lets an indexer
+    // decompose it back out without a second ABI for CurveBuy itself.
+    event SnipeTaxCharged(address indexed payer, address indexed recipient, uint256 amount, uint256 bps);
+    event SnipeTaxExempted(address indexed account);
 
     // Not immutable: the token's constructor needs this curve's real address,
     // so the factory deploys the curve first, then the token, then wires the
@@ -109,7 +131,19 @@ contract PonsV2BondingCurve is ReentrancyGuard {
     // the creator in full.
     uint256 public immutable creatorTaxBps;
     uint256 public immutable graduationThreshold;
+    // Opening-window terms, frozen at deployment. `launchedAt` is set in the
+    // constructor rather than in initialize() so the window cannot be extended
+    // by delaying the wiring call, and so it stays immutable.
+    uint64 public immutable launchedAt;
+    uint16 public immutable snipeTaxStartBps;
+    uint32 public immutable snipeTaxWindow;
+    uint32 public immutable snipeTaxHalfLife;
     bool public buybackEnabled;
+    // Written once, inside the launch transaction, by initialize(). There is
+    // deliberately no setter: an exemption granted after launch would let a
+    // creator wave a friendly address through the window that everyone else
+    // paid to cross.
+    mapping(address => bool) public snipeTaxExempt;
 
     uint256 public quoteFeeBalance;
     // The slice of `quoteFeeBalance` already earmarked for buyback-and-lock,
@@ -178,7 +212,8 @@ contract PonsV2BondingCurve is ReentrancyGuard {
         uint256 feeBps_,
         uint256 creatorTaxBps_,
         bool buybackEnabled_,
-        uint256 graduationThreshold_
+        uint256 graduationThreshold_,
+        SnipeTaxTerms memory snipeTax_
     ) {
         if (deployer_ == address(0) || factory_ == address(0)) revert ZeroAddress();
         if (address(feePolicy_) == address(0) || address(feeEscrow_) == address(0)) revert ZeroAddress();
@@ -194,6 +229,30 @@ contract PonsV2BondingCurve is ReentrancyGuard {
         // defends its own invariant rather than inheriting it: a combined fee
         // at or above the whole trade would break the quote accounting.
         if (feeBps_ + creatorTaxBps_ > MAX_TOTAL_TRADE_FEE_BPS) revert InvalidFeePolicy();
+        // Zero start disables the window; anything else has to describe a
+        // window that actually closes, or a launch could tax buys forever.
+        if (snipeTax_.startBps != 0) {
+            if (snipeTax_.startBps > MAX_SNIPE_TAX_START_BPS) revert InvalidSnipeTaxTerms();
+            if (snipeTax_.window == 0 || snipeTax_.halfLife == 0) revert InvalidSnipeTaxTerms();
+            if (snipeTax_.halfLife > snipeTax_.window) revert InvalidSnipeTaxTerms();
+            // The binding constraint for buy(): at maximum tax the gross-up
+            // denominator is BASIS_POINTS minus all three legs, and it has to
+            // stay comfortably positive. Checked here so buy() can rely on it
+            // unconditionally rather than re-deriving it every call.
+            if (feeBps_ + creatorTaxBps_ + snipeTax_.startBps > BASIS_POINTS - MIN_BUYER_SHARE_BPS) {
+                revert InvalidSnipeTaxTerms();
+            }
+        } else if (snipeTax_.window != 0 || snipeTax_.halfLife != 0) {
+            // Terms that look configured but do nothing are almost always a
+            // caller mistake, and a silently inert window is worse than a
+            // revert at launch.
+            revert InvalidSnipeTaxTerms();
+        }
+
+        launchedAt = uint64(block.timestamp);
+        snipeTaxStartBps = snipeTax_.startBps;
+        snipeTaxWindow = snipeTax_.window;
+        snipeTaxHalfLife = snipeTax_.halfLife;
 
         pairToken = pairToken_;
         deployer = deployer_;
@@ -240,9 +299,22 @@ contract PonsV2BondingCurve is ReentrancyGuard {
      * one is used as the trigger, the graduated pool is seeded with the same
      * amounts at the same price on every launch.
      */
-    function initialize(address token_) external onlyFactory {
+    function initialize(address token_, address launcher, address[] calldata snipeTaxExemptions)
+        external
+        onlyFactory
+    {
         if (token != address(0)) revert AlreadyInitialized();
         if (token_ == address(0)) revert ZeroAddress();
+        // Bounded, and written in the same transaction as the launch itself.
+        if (snipeTaxExemptions.length > MAX_SNIPE_TAX_EXEMPTIONS) revert ExemptionListTooLong();
+        // Both excused unconditionally. A creator paying a 99% levy to seed
+        // their own launch would make this a tax on launching rather than a
+        // tax on racing. `deployer` holds the creator fee recipient here.
+        _exempt(launcher);
+        _exempt(deployer);
+        for (uint256 i = 0; i < snipeTaxExemptions.length; ++i) {
+            _exempt(snipeTaxExemptions[i]);
+        }
         token = token_;
 
         uint256 supply = IERC20(token_).totalSupply();
@@ -362,6 +434,46 @@ contract PonsV2BondingCurve is ReentrancyGuard {
      * own arguments, and when nothing is clamped it reduces exactly to
      * `tokensOut >= minTokensOut`.
      */
+    /**
+     * @notice Opening buy tax in basis points that `recipient` would pay right
+     * now. Zero once the window has closed, for an exempt address, or for a
+     * launch configured without a window.
+     *
+     * @dev Exponential decay evaluated in integer arithmetic: the tax halves
+     * every `snipeTaxHalfLife` seconds, with a linear interpolation between
+     * halvings so the curve does not fall in visible cliffs. Deliberately not
+     * a fixed-point exp(): this is read inside buy() on every trade, and an
+     * approximation that is monotonically decreasing and provably bounded by
+     * `snipeTaxStartBps` is worth more here than one that is precise.
+     *
+     * Keyed on the token recipient rather than msg.sender. Keying it on the
+     * caller would mean any router — including one a sniper deploys — could
+     * be exempted once and then resell entry to the window.
+     */
+    function _exempt(address account) private {
+        // Duplicates and the zero address are skipped rather than rejected:
+        // the list is assembled from three sources that do not know about each
+        // other, and a cosmetic overlap should not fail a valid launch.
+        if (account == address(0) || snipeTaxExempt[account]) return;
+        snipeTaxExempt[account] = true;
+        emit SnipeTaxExempted(account);
+    }
+
+    function currentSnipeTaxBps(address recipient) public view returns (uint256) {
+        if (snipeTaxStartBps == 0 || snipeTaxExempt[recipient]) return 0;
+        uint256 elapsed = block.timestamp - launchedAt;
+        if (elapsed >= snipeTaxWindow) return 0;
+
+        uint256 steps = elapsed / snipeTaxHalfLife;
+        // Past sixteen halvings the result rounds to zero in basis points
+        // anyway, and the shift below would be undefined for large shifts.
+        if (steps >= 16) return 0;
+        uint256 upper = uint256(snipeTaxStartBps) >> steps;
+        uint256 lower = upper >> 1;
+        uint256 into = elapsed % snipeTaxHalfLife;
+        return upper - ((upper - lower) * into) / snipeTaxHalfLife;
+    }
+
     function buy(uint256 quoteIn, uint256 minTokensOut, address recipient)
         external
         payable
@@ -384,10 +496,17 @@ contract PonsV2BondingCurve is ReentrancyGuard {
         uint256 quoteReserveBefore = phantomQuote + trackedQuote - quoteFeeBalance - creatorTaxBalance;
         uint256 tokenReserveBefore = trackedTokens;
 
+        // Read once and reused for the clamped-fill branch: a second read
+        // would return the same value in the same block, but pinning it makes
+        // the gross-up denominator provably the one the fill was priced with.
+        uint256 snipeBps = currentSnipeTaxBps(recipient);
+
         uint256 spent = received;
         uint256 fee = (spent * feeBps) / BASIS_POINTS;
         uint256 tax = (spent * creatorTaxBps) / BASIS_POINTS;
-        tokensOut = PonsV2BondingCurveMath.getAmountOut(spent - fee - tax, quoteReserveBefore, tokenReserveBefore, 0);
+        uint256 snipe = (spent * snipeBps) / BASIS_POINTS;
+        tokensOut =
+            PonsV2BondingCurveMath.getAmountOut(spent - fee - tax - snipe, quoteReserveBefore, tokenReserveBefore, 0);
 
         uint256 sellable = tokenReserveBefore > reservedTokens ? tokenReserveBefore - reservedTokens : 0;
         if (sellable == 0) revert CurveGraduated();
@@ -396,20 +515,35 @@ contract PonsV2BondingCurve is ReentrancyGuard {
             tokensOut = sellable;
             // Price the clamped fill from the token side, then gross the
             // result back up so the fee legs still come out of the input.
+            // The denominator is bounded below by MIN_BUYER_SHARE_BPS by the
+            // constructor's check, so it cannot approach zero here.
             uint256 net = PonsV2BondingCurveMath.getAmountIn(sellable, quoteReserveBefore, tokenReserveBefore, 0);
             spent = Math.min(
-                Math.mulDiv(net, BASIS_POINTS, BASIS_POINTS - feeBps - creatorTaxBps, Math.Rounding.Ceil), received
+                Math.mulDiv(net, BASIS_POINTS, BASIS_POINTS - feeBps - creatorTaxBps - snipeBps, Math.Rounding.Ceil),
+                received
             );
             fee = (spent * feeBps) / BASIS_POINTS;
             tax = (spent * creatorTaxBps) / BASIS_POINTS;
+            snipe = (spent * snipeBps) / BASIS_POINTS;
         }
+
+        // A buy that yields nothing is a buy that only pays fees. Reachable
+        // for dust inside the opening window, where the levy consumes the
+        // whole input before it reaches the curve. Refusing it is strictly
+        // safer than settling it: nobody is denied a fill they would have
+        // wanted, and the caller keeps their funds.
+        if (tokensOut == 0) revert ZeroAmount();
 
         // Price bound rather than quantity bound, so a partial fill honours
         // the caller's terms instead of failing them. Identical to
         // `tokensOut >= minTokensOut` whenever `spent == received`.
         if (spent * minTokensOut > received * tokensOut) revert SlippageExceeded(tokensOut, minTokensOut);
 
-        _accrueFees(fee, tax);
+        // The levy joins the base fee rather than travelling in its own
+        // bucket, so it flows through the existing protocol / buyback /
+        // creator split untouched. No new distribution path means no new
+        // surface for it to be diverted through.
+        _accrueFees(fee + snipe, tax);
         trackedQuote += spent;
         trackedTokens -= tokensOut;
         IERC20(token).safeTransfer(recipient, tokensOut);
@@ -420,7 +554,8 @@ contract PonsV2BondingCurve is ReentrancyGuard {
             _sendQuote(msg.sender, refund);
         }
 
-        emit CurveBuy(msg.sender, recipient, spent, tokensOut, fee, tax);
+        if (snipe != 0) emit SnipeTaxCharged(msg.sender, recipient, snipe, snipeBps);
+        emit CurveBuy(msg.sender, recipient, spent, tokensOut, fee + snipe, tax);
         _tryAutoGraduate();
     }
 

--- a/contractsV2/src/v2/PonsV2LaunchDeployer.sol
+++ b/contractsV2/src/v2/PonsV2LaunchDeployer.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.26;
 import {PonsV2LauncherToken} from "./PonsV2LauncherToken.sol";
 import {PonsV2BondingCurve} from "./PonsV2BondingCurve.sol";
 import {PonsV2BuybackVault} from "./PonsV2BuybackVault.sol";
-import {FeePolicySnapshot, IPonsV2FeeEscrow, IPonsV2FeePolicy} from "./interfaces/ILaunchpadV2.sol";
+import {FeePolicySnapshot, IPonsV2FeeEscrow, IPonsV2FeePolicy, SnipeTaxTerms} from "./interfaces/ILaunchpadV2.sol";
 
 /**
  * @notice Every input PonsV2LaunchFactory hands the deployer to stand up one
@@ -25,6 +25,7 @@ struct LaunchDeployment {
     uint256 creatorTaxBps;
     bool buybackEnabled;
     uint256 graduationThreshold;
+    SnipeTaxTerms snipeTax;
     uint256 supply;
     string name;
     string symbol;
@@ -97,7 +98,8 @@ contract PonsV2LaunchDeployer {
                 params.curveFeeBps,
                 params.creatorTaxBps,
                 params.buybackEnabled,
-                params.graduationThreshold
+                params.graduationThreshold,
+                params.snipeTax
             )
         );
         token = address(

--- a/contractsV2/src/v2/PonsV2LaunchFactory.sol
+++ b/contractsV2/src/v2/PonsV2LaunchFactory.sol
@@ -33,7 +33,8 @@ import {
     FeePolicySnapshot,
     GraduationPhase,
     IPonsV2FeeEscrow,
-    IPonsV2LaunchFactory
+    IPonsV2LaunchFactory,
+    SnipeTaxTerms
 } from "./interfaces/ILaunchpadV2.sol";
 
 /**
@@ -59,6 +60,16 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
     uint256 private constant MAX_CURVE_FEE_BPS = 1_000; // 10%
     uint256 private constant MAX_CREATOR_TAX_CEILING_BPS = 1_000; // 10%
     uint256 private constant MAX_TOTAL_TRADE_FEE_BPS = 2_000; // 20%
+    // Mirrors PonsV2BondingCurve. The curve enforces its own copy; these exist
+    // so a config that could never deploy is rejected at addLaunchConfig time
+    // rather than at the first launch that tries to use it.
+    uint256 private constant MAX_SNIPE_TAX_START_BPS = 9_900; // 99%
+    uint256 private constant MIN_BUYER_SHARE_BPS = 100; // 1%
+    uint256 private constant MAX_SNIPE_TAX_EXEMPTIONS = 32;
+    // The longest opening window a config may declare. Past a minute the
+    // mechanism stops being anti-latency and starts being a standing tax on
+    // anyone who did not have advance notice of the launch.
+    uint256 private constant MAX_SNIPE_TAX_WINDOW = 60;
     uint8 private constant MIN_PAIR_TOKEN_DECIMALS = 6;
     // Smallest supply a launch may declare, and the reference supply the
     // quotability check assumes when it runs before any config is known.
@@ -126,6 +137,9 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         //   uint16  policy.buybackBurnBps
         //   uint16  policy.hookFeeBps
         //   uint16  policy.maxInternalPriceImpactBps
+        //   uint16  config.snipeTax.startBps
+        //   uint32  config.snipeTax.window
+        //   uint32  config.snipeTax.halfLife
         //
         // It spans every owner-controlled term that fixes what the creator is
         // buying, not the phantom reserve and threshold alone, so the supply,
@@ -147,6 +161,10 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         uint24 poolFee;
         int24 tickSpacing;
         bool enabled;
+        // Opening-window buy tax applied by every curve deployed from this
+        // config. A zero startBps reproduces the pre-window behaviour exactly,
+        // so configs written before this field existed remain expressible.
+        SnipeTaxTerms snipeTax;
     }
 
     /**
@@ -217,9 +235,14 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
     error LaunchEconomicsMismatch(bytes32 expected, bytes32 actual);
     error InexactTransfer(address token, uint256 expected, uint256 received);
     error GraduationSeedNotViable();
+
+    error SnipeTaxTermsInvalid();
+    error ExemptionListTooLong();
+    error NotTrustedRouter();
     error SupplyTooHigh();
     error GraduationRescueTooEarly(uint256 availableAt);
 
+    event TrustedRouterUpdated(address indexed router, bool trusted);
     event TokenLaunched(
         address indexed token,
         address indexed curve,
@@ -285,6 +308,10 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
     bool public launchEnabled;
 
     mapping(address launcher => bool enabled) public whitelistedLaunchers;
+    // Contracts allowed to call launchTokenFor. A trusted router may attribute
+    // a launch to someone else, but never grants them launch eligibility: the
+    // named launcher still has to pass canLaunch on their own.
+    mapping(address router => bool trusted) public trustedRouters;
     mapping(address pairToken => bool approved) public approvedPairTokens;
     mapping(address pairToken => PairTokenEconomics economics) public pairTokenEconomics;
     mapping(address token => FeePolicySnapshot policy) private _launchFeePolicies;
@@ -406,6 +433,18 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         if (launcher == address(0)) revert ZeroAddress();
         whitelistedLaunchers[launcher] = enabled;
         emit WhitelistedLauncherUpdated(launcher, enabled);
+    }
+
+    /**
+     * @notice Trusts or untrusts a router for launchTokenFor.
+     * @dev Owner-gated because a router chooses the launcher address it
+     * attributes a launch to. It cannot mint eligibility, but it can decide
+     * whose name a launch carries, which is enough to warrant a gate.
+     */
+    function setTrustedRouter(address router, bool trusted) external onlyOwner {
+        if (router == address(0)) revert ZeroAddress();
+        trustedRouters[router] = trusted;
+        emit TrustedRouterUpdated(router, trusted);
     }
 
     /**
@@ -570,6 +609,37 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
      * creator supplies rather than one the protocol sets, so a change makes
      * the launch revert on its own rather than silently reprice.
      */
+    /**
+     * @dev Rejects opening-window terms no curve could accept. The combined
+     * ceiling is checked here against the base trade fee only, not against
+     * `maxCreatorTaxBps`: pairing the worst-case creator tax with the worst-
+     * case opening tax would cap a config at roughly 88% for the sake of a
+     * combination most launches never reach. The curve enforces the exact
+     * bound against the creator tax actually chosen, so an incompatible pair
+     * fails at launch rather than being forbidden at configuration.
+     */
+    function _validateSnipeTaxTerms(SnipeTaxTerms calldata terms, uint256 curveFeeBps) private pure {
+        if (terms.startBps == 0) {
+            if (terms.window != 0 || terms.halfLife != 0) revert SnipeTaxTermsInvalid();
+            return;
+        }
+        if (terms.startBps > MAX_SNIPE_TAX_START_BPS) revert SnipeTaxTermsInvalid();
+        if (terms.window == 0 || terms.window > MAX_SNIPE_TAX_WINDOW) revert SnipeTaxTermsInvalid();
+        if (terms.halfLife == 0 || terms.halfLife > terms.window) revert SnipeTaxTermsInvalid();
+        if (curveFeeBps + terms.startBps > BASIS_POINTS - MIN_BUYER_SHARE_BPS) {
+            revert SnipeTaxTermsInvalid();
+        }
+    }
+
+    /**
+     * @notice Whether `account` may create a launch right now. Equivalent to
+     * the gate launchToken applies, exposed so a router can enforce the
+     * caller's own eligibility rather than borrowing its own.
+     */
+    function canLaunch(address account) public view returns (bool) {
+        return launchEnabled || whitelistedLaunchers[account];
+    }
+
     function _economicsDigest(
         LaunchConfig memory config,
         FeePolicySnapshot memory policy,
@@ -587,7 +657,10 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
                 policy.protocolFeeShareBps,
                 policy.buybackBurnBps,
                 policy.hookFeeBps,
-                policy.maxInternalPriceImpactBps
+                policy.maxInternalPriceImpactBps,
+                config.snipeTax.startBps,
+                config.snipeTax.window,
+                config.snipeTax.halfLife
             )
         );
     }
@@ -604,9 +677,48 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         nonReentrant
         returns (address token, address curve)
     {
+        return _launchToken(params, launchConfigId, pairToken, msg.sender, new address[](0));
+    }
+
+    /**
+     * @notice Launch with addresses excused from the opening window, and
+     * optionally on someone else's behalf.
+     *
+     * The launcher and the creator fee recipient are excused automatically;
+     * `snipeTaxExemptions` is for the rest of a team or a known market maker.
+     * Exemptions are fixed at creation and never extendable — granting one
+     * after a launch is live would wave an address through a window every
+     * other buyer paid to cross, so there is no setter anywhere.
+     *
+     * @param launcher Address credited as deployer. Zero means the caller.
+     * Naming anyone else requires the caller to be a trusted router, and a
+     * router does not lend its own eligibility: `launcher` is gated through
+     * canLaunch exactly as a direct caller would be. Without that, the
+     * whitelist would be defeated by routing through a whitelisted contract.
+     */
+    function launchTokenFor(
+        TokenParams calldata params,
+        uint256 launchConfigId,
+        address pairToken,
+        address launcher,
+        address[] calldata snipeTaxExemptions
+    ) external payable nonReentrant returns (address token, address curve) {
+        address attributed = launcher == address(0) ? msg.sender : launcher;
+        if (attributed != msg.sender && !trustedRouters[msg.sender]) revert NotTrustedRouter();
+        return _launchToken(params, launchConfigId, pairToken, attributed, snipeTaxExemptions);
+    }
+
+    function _launchToken(
+        TokenParams calldata params,
+        uint256 launchConfigId,
+        address pairToken,
+        address launcher,
+        address[] memory snipeTaxExemptions
+    ) private returns (address token, address curve) {
         if (address(launchDeployer) == address(0)) revert LaunchDeployerNotSet();
         _requireLaunchDependenciesWired();
-        if (!launchEnabled && !whitelistedLaunchers[msg.sender]) revert NotWhitelisted();
+        if (!canLaunch(launcher)) revert NotWhitelisted();
+        if (snipeTaxExemptions.length > MAX_SNIPE_TAX_EXEMPTIONS) revert ExemptionListTooLong();
         if (msg.value != launchFee) revert LaunchFeeNotPaid();
         if (launchConfigId >= _launchConfigs.length) revert InvalidLaunchConfigId();
         if (bytes(params.name).length == 0 || bytes(params.symbol).length == 0) revert InvalidTokenParams();
@@ -653,13 +765,13 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         // has their fee and nothing has been deployed.
         _requireSeedableTerms(config.supply, phantomQuote, graduationThreshold, config.tickSpacing);
 
-        address creatorFeeRecipient = params.creatorFeeRecipient == address(0) ? msg.sender : params.creatorFeeRecipient;
+        address creatorFeeRecipient = params.creatorFeeRecipient == address(0) ? launcher : params.creatorFeeRecipient;
 
         (token, curve) = launchDeployer.deployLaunch(
             LaunchDeployment({
                 pairToken: pairToken,
                 creatorFeeRecipient: creatorFeeRecipient,
-                originalDeployer: msg.sender,
+                originalDeployer: launcher,
                 feePolicy: memeHook,
                 policy: policy,
                 feeEscrow: feeEscrow,
@@ -669,6 +781,7 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
                 creatorTaxBps: params.creatorTaxBps,
                 buybackEnabled: params.buybackEnabled,
                 graduationThreshold: graduationThreshold,
+                snipeTax: config.snipeTax,
                 supply: config.supply,
                 name: params.name,
                 symbol: params.symbol,
@@ -677,12 +790,12 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
                 socials: params.socials
             })
         );
-        PonsV2BondingCurve(curve).initialize(token);
+        PonsV2BondingCurve(curve).initialize(token, launcher, snipeTaxExemptions);
 
         _launchedTokens[token] = LaunchedToken({
             token: token,
             curve: curve,
-            deployer: msg.sender,
+            deployer: launcher,
             creatorFeeRecipient: creatorFeeRecipient,
             pairToken: pairToken,
             graduationThreshold: graduationThreshold,
@@ -702,7 +815,7 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         // protocol recipient, which may be a contract that calls back in.
         _payLaunchFee();
 
-        emit TokenLaunched(token, curve, msg.sender, pairToken, launchConfigId, graduationThreshold);
+        emit TokenLaunched(token, curve, launcher, pairToken, launchConfigId, graduationThreshold);
     }
 
     // ---------------------------------------------------------------------
@@ -1308,6 +1421,7 @@ contract PonsV2LaunchFactory is Ownable2Step, ReentrancyGuard, IPonsV2LaunchFact
         if (config.graduationThreshold == 0) revert InvalidGraduationThreshold();
         if (config.tickSpacing <= 0 || config.tickSpacing > MAX_TICK_SPACING) revert InvalidTickSpacing();
         if (config.poolFee != 0) revert CoreLpFeeMustBeZero();
+        _validateSnipeTaxTerms(config.snipeTax, config.curveFeeBps);
         _requireQuotable(config.phantomQuote, config.supply, config.curveFeeBps);
     }
 

--- a/contractsV2/src/v2/PonsV2LaunchRouter.sol
+++ b/contractsV2/src/v2/PonsV2LaunchRouter.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {PonsV2BondingCurve} from "./PonsV2BondingCurve.sol";
+import {PonsV2LaunchFactory} from "./PonsV2LaunchFactory.sol";
+
+/**
+ * @title PonsV2LaunchRouter
+ * @notice Creates a launch and takes its first position in one transaction.
+ *
+ * The opening-window levy in PonsV2BondingCurve makes a creator's own first
+ * buy prohibitively expensive if it lands as a separate transaction, since
+ * nothing distinguishes it from a bot's. Rather than weaken the window, this
+ * router closes it for the one case that is provably not a race: the buy that
+ * is atomic with the launch itself and therefore cannot have observed it.
+ *
+ * @dev A separate contract purely for bytecode budget. PonsV2LaunchFactory
+ * already sits within a few hundred bytes of EIP-170's deployed-code limit,
+ * and this logic would not fit alongside it.
+ *
+ * The owner must call `setTrustedRouter(address(this), true)` on the factory
+ * before this contract works. That trust lets it attribute a launch to its
+ * caller; it does not let it launch on behalf of someone who could not launch
+ * themselves, because the factory still gates the named launcher through
+ * `canLaunch`.
+ */
+contract PonsV2LaunchRouter is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    error ZeroAddress();
+    error NativeValueMismatch(uint256 supplied, uint256 expected);
+    error UnexpectedNativeValue();
+    error RefundFailed();
+
+    event LaunchedAndBought(
+        address indexed launcher, address indexed token, address curve, uint256 quoteIn, uint256 tokensOut
+    );
+
+    PonsV2LaunchFactory public immutable factory;
+
+    /**
+     * @dev Set to the curve for the duration of a buy and cleared immediately
+     * after. The curve refunds an unfilled remainder to `msg.sender`, which is
+     * this router, so the router has to be able to receive ETH — but only from
+     * the curve it is mid-call with. Without the guard, `receive()` would be
+     * an open door for value this contract has no way to attribute.
+     */
+    address private _refundSource;
+
+    constructor(PonsV2LaunchFactory factory_) {
+        if (address(factory_) == address(0)) revert ZeroAddress();
+        factory = factory_;
+    }
+
+    receive() external payable {
+        if (msg.sender != _refundSource) revert UnexpectedNativeValue();
+    }
+
+    /**
+     * @notice Launches a token and immediately buys from its curve, exempt
+     * from the opening window.
+     *
+     * @param quoteIn Amount of the quote asset to spend on the opening buy.
+     * Zero launches without buying, which is a plain launch that still routes
+     * the exemption list through.
+     * @param recipient Receives the tokens, and is exempted from the window.
+     * Exempting the recipient rather than the caller is what makes the
+     * exemption non-transferable: a sniper cannot buy entry by routing
+     * through an address that happens to be excused.
+     *
+     * @dev For a native-quote launch the caller sends `launchFee + quoteIn`.
+     * For an ERC-20 quote they send `launchFee` and this contract pulls
+     * `quoteIn` from them, so the router needs an allowance on the quote asset
+     * rather than on the curve.
+     */
+    function launchAndBuy(
+        PonsV2LaunchFactory.TokenParams calldata params,
+        uint256 launchConfigId,
+        address pairToken,
+        uint256 quoteIn,
+        uint256 minTokensOut,
+        address recipient,
+        address[] calldata snipeTaxExemptions
+    ) external payable nonReentrant returns (address token, address curve, uint256 tokensOut) {
+        if (recipient == address(0)) revert ZeroAddress();
+
+        uint256 launchFee = factory.launchFee();
+        bool nativeQuote = pairToken == address(0);
+        uint256 expectedValue = nativeQuote ? launchFee + quoteIn : launchFee;
+        if (msg.value != expectedValue) revert NativeValueMismatch(msg.value, expectedValue);
+
+        // The factory prepends the launcher and the creator fee recipient, so
+        // only the recipient and the caller's own list are passed on here.
+        address[] memory exemptions = new address[](snipeTaxExemptions.length + 1);
+        exemptions[0] = recipient;
+        for (uint256 i = 0; i < snipeTaxExemptions.length; ++i) {
+            exemptions[i + 1] = snipeTaxExemptions[i];
+        }
+
+        (token, curve) = factory.launchTokenFor{value: launchFee}(
+            params, launchConfigId, pairToken, msg.sender, exemptions
+        );
+
+        if (quoteIn == 0) {
+            emit LaunchedAndBought(msg.sender, token, curve, 0, 0);
+            return (token, curve, 0);
+        }
+
+        _refundSource = curve;
+        if (nativeQuote) {
+            tokensOut = PonsV2BondingCurve(payable(curve)).buy{value: quoteIn}(quoteIn, minTokensOut, recipient);
+        } else {
+            IERC20 quote = IERC20(pairToken);
+            quote.safeTransferFrom(msg.sender, address(this), quoteIn);
+            // forceApprove rather than approve: the quote asset is only known
+            // to be ERC-20-shaped, and a non-standard token may not return a
+            // bool or may reject a non-zero-to-non-zero change.
+            quote.forceApprove(curve, quoteIn);
+            tokensOut = PonsV2BondingCurve(payable(curve)).buy(quoteIn, minTokensOut, recipient);
+            // The curve pulls only what it fills, so a clamped fill leaves
+            // both an allowance and a balance behind. Clearing the allowance
+            // matters more than the dust: a standing approval on a curve
+            // anyone can call is a liability that outlives this transaction.
+            quote.forceApprove(curve, 0);
+            uint256 remaining = quote.balanceOf(address(this));
+            if (remaining != 0) quote.safeTransfer(msg.sender, remaining);
+        }
+        _refundSource = address(0);
+
+        // A clamped fill refunds native quote to the caller of buy(), which is
+        // this contract. Forwarding the whole balance rather than a computed
+        // remainder means a rounding difference cannot strand value here.
+        uint256 balance = address(this).balance;
+        if (balance != 0) {
+            (bool ok,) = msg.sender.call{value: balance}("");
+            if (!ok) revert RefundFailed();
+        }
+
+        emit LaunchedAndBought(msg.sender, token, curve, quoteIn, tokensOut);
+    }
+}

--- a/contractsV2/src/v2/interfaces/ILaunchpadV2.sol
+++ b/contractsV2/src/v2/interfaces/ILaunchpadV2.sol
@@ -42,6 +42,33 @@ struct FeePolicySnapshot {
 }
 
 /**
+ * @notice Opening-window buy tax terms, frozen into a curve at deployment.
+ *
+ * The tax decays from `startBps` to zero over `window` seconds, halving once
+ * per `halfLife` seconds, and applies to buys only. It exists to price out
+ * latency racing at t=0: Robinhood Chain sequences first-come-first-served
+ * with no public mempool, so the contestable edge is measured in the
+ * milliseconds between the launch transaction landing and a listener's buy
+ * reaching the sequencer. A quantity cap cannot reach that edge because it is
+ * defeated by splitting wallets; a tax priced per unit of capital can.
+ *
+ * `startBps == 0` disables the mechanism entirely and restores the curve's
+ * original behaviour, so existing launch configs remain expressible.
+ *
+ * @dev Resolution is deliberately whole seconds. `block.timestamp` is the
+ * only clock available here: on an Arbitrum Orbit chain `block.number`
+ * approximates the *L1* block number and cannot be used to measure L2 time.
+ * Every block inside the same second therefore sees the same tax, which is
+ * the intended behaviour rather than a limitation — a bot's advantage over a
+ * human is sub-second, so a one-second floor removes it wholesale.
+ */
+struct SnipeTaxTerms {
+    uint16 startBps;
+    uint32 window;
+    uint32 halfLife;
+}
+
+/**
  * @notice Protocol-owned fee policy read by every bonding curve and by the
  * meme hook. The current policy is snapshotted at launch, while the live
  * sweep operator remains rotatable for operational liveness.


### PR DESCRIPTION
## Why

Every protection in v2 today works on **quantity or structure** — `reservedTokens`
caps what the curve will sell, the whole supply mints to the curve so there is no
pool to snipe at block zero, `_beforeInitialize` blocks pre-initialising the
graduated PoolKey. None of them work on **time**. In the first second of a launch
the curve cannot tell a listener reacting to `TokenLaunched` from a human who
opened the page.

Robinhood Chain sequences FCFS behind a single sequencer with no public mempool,
so classical front-running is impossible — but latency racing is wide open, and
the contestable edge is milliseconds.

v1's `restrictionEndBlock` does not transfer: at ~10 blocks/sec its two-block
window is roughly **200ms**.

## What this does

**Layer 1 — decaying opening buy tax.** `SnipeTaxTerms`
(`startBps`/`window`/`halfLife`) frozen into each curve at deployment, exposed as
`currentSnipeTaxBps(address)`. Charged on the quote leg before the input reaches
the pricing reserve. `startBps == 0` reproduces current behaviour exactly, so
existing launch configs stay expressible.

**Layer 2 — exemptions.** `initialize(token, launcher, address[])`, still
`onlyFactory`, still once. Launcher and creator fee recipient excused
unconditionally, up to 32 more from the creator. No setter.

**Layer 3 — `PonsV2LaunchRouter`.** Atomic launch + buy, so a creator's own
opening buy is not priced as if it were a race. Separate contract for bytecode
budget; needs `setTrustedRouter`.

## Design decisions worth arguing with

These are the four that aren't obvious from the diff:

1. **Whole-second resolution is forced, not chosen.** On an Arbitrum Orbit chain
   `block.number` approximates the *L1* block number and cannot measure L2 time,
   leaving `block.timestamp` as the only clock. Every block within a second sees
   the same rate. I think this is adequate rather than a compromise — a bot's edge
   over a human is sub-second, so a one-second floor removes it wholesale.
2. **Keyed on `recipient`, not `msg.sender`.** Keying on the caller would let any
   router — including one a sniper deploys — be exempted once and then resell
   entry to the window.
3. **Kept outside `MAX_TOTAL_TRADE_FEE_BPS`.** That ceiling governs a creator's
   standing rake for the life of a launch; this levy is transient. Merging them
   would either cap the opening tax where a bot would happily pay it, or raise the
   standing-rake ceiling to 99%. Separate risks, separate limits.
4. **Charged into `_accrueFees`, not a new bucket.** It flows through the existing
   protocol / buyback / creator split untouched. No new distribution path means no
   new surface for it to be diverted through. Side effect worth naming: a heavily
   sniped launch funds a larger buyback. Intended, but a protocol economics call,
   not an engineering one — flagging it for a decision before mainnet.

## Breaking change

`_economicsDigest` preimage goes from **ten values to thirteen** (`snipeTax.startBps`,
`.window`, `.halfLife` appended). Any off-chain code computing `expectedEconomics`
must be updated in lockstep or every pinned launch will revert with
`LaunchEconomicsMismatch`.

`launchToken(params, id, pairToken)` keeps its exact signature and behaviour.

## Behavioural change beyond the levy

`buy()` now reverts `ZeroAmount` when `tokensOut == 0`. Reachable for dust inside
the window, where the levy consumes the whole input before it reaches the curve.
Refusing is strictly safer than settling — nobody is denied a fill they wanted,
and the caller keeps their funds.

## Bytecode budget

`PonsV2LaunchFactory` was the binding constraint. solc 0.8.28,
`--via-ir --optimize --optimize-runs 200`:

| Contract | Before | After |
|---|---|---|
| PonsV2LaunchFactory | 22757 | **24267** / 24576 |
| PonsV2BondingCurve | 9?? | 10448 |
| PonsV2LaunchRouter | — | 3247 |

**309 bytes of headroom.** The first draft carried three launch entry points and
assembled the exemption array in the factory: 24744, over the limit. Collapsing
to two entry points (one full `TokenParams` calldata decode is expensive) and
moving exemption assembly into the curve recovered ~480 bytes. Anything further
added to the factory needs a size check first.

## Not done, deliberately

- **Per-wallet cap during the window.** Defeated by splitting wallets on a chain
  with no identity, and enforcing it means making `buy()` revert — which destroys
  the partial-fill-never-fails property that is currently v2's best anti-grief
  protection. A tax cannot be wallet-split; it is charged per unit of capital.
- **CREATE2 launch addresses.** Worth doing, but not first. A predictable curve
  address lets a sniper prepare calldata and approvals *before* the launch lands;
  today's unpredictable addresses are an accidental protection. Land CREATE2 after
  this window is live, not before.

## Testing

**None included — this repository carries no test harness** (no `foundry.toml`,
no `test/`, no `forge-std`). Verified only that the branch compiles clean from a
fresh clone of `main` with no size warnings.

The suite this needs is listed in `contractsV2/ANTISNIPE.md`. The two that matter
most:

- **graduation invariant**: with the levy at maximum, `reservedTokens` and the
  seeded pool price are identical to a launch without it
- **worst-case rounding**: clamped fill + max levy + max creator tax simultaneously

I'd rather not merge this without at least those two.

## Review guidance

Read in this order: `ANTISNIPE.md` → `PonsV2BondingCurve.sol` (`currentSnipeTaxBps`,
then `buy()`) → `PonsV2LaunchFactory.sol` → `PonsV2LaunchRouter.sol`.

`PonsV2LaunchFactory.sol` has the most scattered diff — import, constants, errors,
`LaunchConfig`, storage, and three separate places in the launch path.

## Open questions

1. A 98% levy at t=0 means an accidental buy at t=0.2s loses nearly everything.
   Mitigation is UI, not contract. If the UI isn't ready, lower `startBps` — 95%
   with a shorter half-life deters almost as well with a far more forgiving tail.
2. `MAX_SNIPE_TAX_WINDOW` is 60s. Past a minute this stops being anti-latency and
   becomes a standing tax on anyone without advance notice.
3. Should the levy fund the buyback split at all? See decision 4 above.