### PR TITLE
feat(v2): add two-way creator fee splitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/cache/
+/out/
+/contractsV2/cache/
+/contractsV2/out/

--- a/README.md
+++ b/README.md
@@ -143,9 +143,14 @@ V2 replaces day-one concentrated liquidity with a fair-launch curve. Every launc
 | `PonsV2GraduationExecutor.sol` | Performs the heavy graduation steps: optional pairToken swap, Permit2 dance, full-range mint, dust sweep |
 | `PonsV2LaunchLocker.sol` | Permanently holds the graduated V4 position NFT; no `collectFees`, no withdrawal path |
 | `PonsV2BuybackVault.sol` | Shared vault holding bought-back supply on a five-year linear vest, split on recorded fee shares |
+| `PonsV2TwoWayFeeSplitter.sol` | Optional immutable two-recipient splitter for native and ERC-20 creator proceeds |
 | `hooks/PonsV2MemeHook.sol` | Singleton V4 hook: swap fee cut, internal memecoin→quote conversion, protocol/creator/buyback split |
 | `interfaces/ILaunchpadV2.sol`, `interfaces/ILaunchpadV2Graduation.sol` | Fee escrow, fee policy snapshot, factory/curve records and graduation hooks |
 | `libraries/PonsV2BondingCurveMath.sol`, `libraries/PonsV2GraduationMath.sol` | Curve pricing and graduation seed math |
+
+See [Two-way creator-fee splitter](contractsV2/examples/two-way-fee-splitter.md)
+for deployment, launch integration, claiming, and optional creator-control
+forwarding.
 
 **Guardrails baked into V2**
 

--- a/contractsV2/examples/two-way-fee-splitter.md
+++ b/contractsV2/examples/two-way-fee-splitter.md
@@ -4,10 +4,14 @@
 want to divide pons v2 proceeds between two fixed wallets. It supports native
 ETH and every ERC-20 supported by the pons fee escrow.
 
-The recipients and ratio are immutable. Either recipient's accrued balance can
-be released independently, so a recipient that rejects ETH does not block the
-other recipient. The second recipient receives any indivisible rounding
-remainder, ensuring no split dust is trapped.
+The recipients and ratio are immutable. Each recipient's share is configured as
+an integer number of units, both shares must be non-zero and add to 20, and each
+unit represents 5%. The supported range is therefore 5%/95% through 95%/5%.
+Fractional remainders carry across allocations, so splitting funds into many
+small allocations produces the same result as allocating the total once.
+
+Either recipient's accrued balance can be released independently, so a
+recipient that rejects ETH does not block the other recipient.
 
 ## Deploy
 
@@ -19,7 +23,8 @@ PonsV2TwoWayFeeSplitter splitter = new PonsV2TwoWayFeeSplitter(
     feeEscrow,
     payable(recipientOne),
     payable(recipientTwo),
-    8_000,
+    16, // 80%
+    4,  // 20%
     IPonsV2CreatorControls(address(launchFactory)),
     controller
 );
@@ -33,7 +38,8 @@ PonsV2TwoWayFeeSplitter splitter = new PonsV2TwoWayFeeSplitter(
     feeEscrow,
     payable(recipientOne),
     payable(recipientTwo),
-    8_000,
+    16, // 80%
+    4,  // 20%
     IPonsV2CreatorControls(address(0)),
     address(0)
 );

--- a/contractsV2/examples/two-way-fee-splitter.md
+++ b/contractsV2/examples/two-way-fee-splitter.md
@@ -1,0 +1,94 @@
+# Two-way creator-fee splitter
+
+`PonsV2TwoWayFeeSplitter` is an optional creator-fee recipient for teams that
+want to divide pons v2 proceeds between two fixed wallets. It supports native
+ETH and every ERC-20 supported by the pons fee escrow.
+
+The recipients and ratio are immutable. Either recipient's accrued balance can
+be released independently, so a recipient that rejects ETH does not block the
+other recipient. The second recipient receives any indivisible rounding
+remainder, ensuring no split dust is trapped.
+
+## Deploy
+
+This example assigns 80% to `recipientOne` and 20% to `recipientTwo` while
+preserving the two pons creator-control calls through an immutable controller:
+
+```solidity
+PonsV2TwoWayFeeSplitter splitter = new PonsV2TwoWayFeeSplitter(
+    feeEscrow,
+    payable(recipientOne),
+    payable(recipientTwo),
+    8_000,
+    IPonsV2CreatorControls(address(launchFactory)),
+    controller
+);
+```
+
+For a completely ownerless deployment, permanently disable creator controls by
+setting both final constructor arguments to zero:
+
+```solidity
+PonsV2TwoWayFeeSplitter splitter = new PonsV2TwoWayFeeSplitter(
+    feeEscrow,
+    payable(recipientOne),
+    payable(recipientTwo),
+    8_000,
+    IPonsV2CreatorControls(address(0)),
+    address(0)
+);
+```
+
+Disabling controls means the splitter can never call
+`transferCreatorFeeRecipient` or `setBuybackEnabled` for a launch that names it
+as the creator fee recipient. A configured controller can invoke only those two
+factory calls; it cannot change the split, replace itself, or move accrued funds
+to any other wallet.
+
+## Launch with the splitter
+
+Pass the deployed splitter as `creatorFeeRecipient` when constructing the
+factory's token parameters:
+
+```solidity
+PonsV2LaunchFactory.TokenParams memory params = PonsV2LaunchFactory.TokenParams({
+    name: name,
+    symbol: symbol,
+    logo: logo,
+    description: description,
+    socials: socials,
+    creatorFeeRecipient: address(splitter),
+    creatorTaxBps: creatorTaxBps,
+    buybackEnabled: buybackEnabled,
+    expectedEconomics: expectedEconomics,
+    salt: salt
+});
+
+(address token, address curve) = launchFactory.launchToken{value: launchFee}(
+    params,
+    launchConfigId,
+    pairToken
+);
+```
+
+The split applies to the creator proceeds credited by pons after the protocol
+and optional buyback shares have been calculated. It does not alter pons's fee
+policy or divide the launched token's supply.
+
+## Claim and release
+
+All operational functions are permissionless. A keeper, either recipient, or
+any third party may call them:
+
+```solidity
+splitter.claimNativeFromPons();
+splitter.releaseNative(recipientOne);
+splitter.releaseNative(recipientTwo);
+
+splitter.claimTokenFromPons(IERC20(pairToken));
+splitter.releaseToken(IERC20(pairToken), recipientOne);
+splitter.releaseToken(IERC20(pairToken), recipientTwo);
+```
+
+Direct transfers are handled with `allocateNative()` and `allocateToken(token)`.
+Failed releases preserve the recipient's pending balance for a later retry.

--- a/contractsV2/examples/two-way-fee-splitter.md
+++ b/contractsV2/examples/two-way-fee-splitter.md
@@ -2,13 +2,15 @@
 
 `PonsV2TwoWayFeeSplitter` is an optional creator-fee recipient for teams that
 want to divide pons v2 proceeds between two fixed wallets. It supports native
-ETH and every ERC-20 supported by the pons fee escrow.
+ETH and standard ERC-20s with exact, stable transfer accounting.
 
 The recipients and ratio are immutable. Each recipient's share is configured as
 an integer number of units, both shares must be non-zero and add to 20, and each
 unit represents 5%. The supported range is therefore 5%/95% through 95%/5%.
 Fractional remainders carry across allocations, so splitting funds into many
 small allocations produces the same result as allocating the total once.
+Neither recipient may be the splitter itself, including when its deployment
+address is predicted in advance.
 
 Either recipient's accrued balance can be released independently, so a
 recipient that rejects ETH does not block the other recipient.
@@ -98,3 +100,32 @@ splitter.releaseToken(IERC20(pairToken), recipientTwo);
 
 Direct transfers are handled with `allocateNative()` and `allocateToken(token)`.
 Failed releases preserve the recipient's pending balance for a later retry.
+
+## ERC-20 requirements
+
+Only ERC-20s for which an exact transfer reduces the splitter's balance and
+increases the recipient's balance by the requested amount are supported. A
+release reverts and preserves its pending balance if either balance delta is
+not exact. If the splitter's token balance falls below the total pending amount,
+all releases remain blocked until full backing is restored so release order
+cannot determine which recipient absorbs a loss.
+
+Fee-on-transfer, negative-rebase, blocklisting, and otherwise mutable or
+upgradeable token behavior can violate those assumptions and is unsupported.
+Positive rebases or unsolicited transfers remain unallocated until someone
+calls `allocateToken(token)`.
+
+## Robinhood Chain fork verification
+
+The integration test uses the deployed pons v2 factory at
+`0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e` and its live fee escrow on a
+local fork. It verifies native and ERC-20 credit, claim, split, and release
+semantics without broadcasting a transaction:
+
+```sh
+ROBINHOOD_RPC_URL=https://rpc.mainnet.chain.robinhood.com \
+  forge test --match-contract PonsV2TwoWayFeeSplitterForkTest -vv
+```
+
+The fork test is skipped when `ROBINHOOD_RPC_URL` is unset, so the offline unit
+suite remains deterministic.

--- a/contractsV2/foundry.toml
+++ b/contractsV2/foundry.toml
@@ -1,0 +1,16 @@
+[profile.default]
+src = "src/v2/utilities"
+test = "test"
+libs = ["lib"]
+solc_version = "0.8.26"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 200
+
+remappings = [
+  "@openzeppelin/=lib/openzeppelin-contracts/",
+  "@uniswap/v4-core/=lib/v4-core/",
+  "@uniswap/v4-hooks-public/=lib/v4-hooks-public/",
+  "@uniswap/v4-periphery/=lib/v4-periphery/",
+  "permit2/=lib/v4-periphery/lib/permit2/",
+]

--- a/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
+++ b/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IPonsV2FeeEscrow} from "../interfaces/ILaunchpadV2.sol";
+
+/**
+ * @notice The two creator-only controls exposed by PonsV2LaunchFactory.
+ */
+interface IPonsV2CreatorControls {
+    function transferCreatorFeeRecipient(address token, address newRecipient) external;
+    function setBuybackEnabled(address token, bool enabled) external;
+}
+
+/**
+ * @title PonsV2TwoWayFeeSplitter
+ * @author bananawalnut
+ * @notice Optional creator-fee recipient that splits native ETH and ERC-20
+ * proceeds between two immutable recipients at an immutable ratio.
+ *
+ * @dev Pons v2 records this contract as `creatorFeeRecipient`. Anyone may
+ * claim its accrued balance from the pons fee escrow, allocate direct or
+ * forced transfers, and release either recipient's balance. No caller can
+ * change the economic terms or redirect the held funds.
+ *
+ * An optional immutable controller preserves the two actions pons reserves
+ * for the current creator fee recipient: transferring future creator fees
+ * and enabling or disabling buybacks. Configure both `creatorControls_` and
+ * `controller_` as zero to disable those actions permanently. A configured
+ * controller cannot alter this splitter's recipients, ratio, or accrued
+ * balances, and cannot replace itself.
+ */
+contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint16 public constant BASIS_POINTS = 10_000;
+
+    IPonsV2FeeEscrow public immutable feeEscrow;
+    IPonsV2CreatorControls public immutable creatorControls;
+    address public immutable controller;
+    address payable public immutable recipientOne;
+    address payable public immutable recipientTwo;
+    uint16 public immutable recipientOneShareBps;
+    uint16 public immutable recipientTwoShareBps;
+
+    mapping(address recipient => uint256 amount) public pendingNative;
+    mapping(address token => mapping(address recipient => uint256 amount)) public pendingToken;
+
+    error ZeroAddress();
+    error DuplicateRecipient();
+    error InvalidShare();
+    error InvalidControllerConfiguration();
+    error NotController();
+    error UnknownRecipient();
+    error NothingToRelease();
+    error NativeTransferFailed(address recipient, uint256 amount);
+    error AccountingInvariant();
+
+    event NativeAllocated(uint256 amount, uint256 recipientOneAmount, uint256 recipientTwoAmount);
+    event TokenAllocated(address indexed token, uint256 amount, uint256 recipientOneAmount, uint256 recipientTwoAmount);
+    event NativeReleased(address indexed recipient, uint256 amount);
+    event TokenReleased(address indexed token, address indexed recipient, uint256 amount);
+    event CreatorFeeRecipientTransferred(address indexed token, address indexed newRecipient);
+    event BuybackEnabledSet(address indexed token, bool enabled);
+
+    modifier onlyController() {
+        _requireController();
+        _;
+    }
+
+    constructor(
+        IPonsV2FeeEscrow feeEscrow_,
+        address payable recipientOne_,
+        address payable recipientTwo_,
+        uint16 recipientOneShareBps_,
+        IPonsV2CreatorControls creatorControls_,
+        address controller_
+    ) {
+        if (address(feeEscrow_) == address(0) || recipientOne_ == address(0) || recipientTwo_ == address(0)) {
+            revert ZeroAddress();
+        }
+        if (recipientOne_ == recipientTwo_) revert DuplicateRecipient();
+        if (recipientOneShareBps_ == 0 || recipientOneShareBps_ >= BASIS_POINTS) revert InvalidShare();
+
+        bool controlsDisabled = address(creatorControls_) == address(0) && controller_ == address(0);
+        bool controlsEnabled = address(creatorControls_) != address(0) && controller_ != address(0);
+        if (!controlsDisabled && !controlsEnabled) revert InvalidControllerConfiguration();
+
+        feeEscrow = feeEscrow_;
+        recipientOne = recipientOne_;
+        recipientTwo = recipientTwo_;
+        recipientOneShareBps = recipientOneShareBps_;
+        recipientTwoShareBps = BASIS_POINTS - recipientOneShareBps_;
+        creatorControls = creatorControls_;
+        controller = controller_;
+    }
+
+    receive() external payable {}
+
+    /**
+     * @notice Claims every native fee currently credited to the splitter and
+     * allocates it together with any other unaccounted native balance.
+     */
+    function claimNativeFromPons() external nonReentrant returns (uint256 claimed, uint256 allocated) {
+        claimed = feeEscrow.claim();
+        allocated = _allocateNative();
+    }
+
+    /**
+     * @notice Claims every `token` fee currently credited to the splitter and
+     * allocates it together with any other unaccounted `token` balance.
+     */
+    function claimTokenFromPons(IERC20 token) external nonReentrant returns (uint256 claimed, uint256 allocated) {
+        if (address(token) == address(0)) revert ZeroAddress();
+        claimed = feeEscrow.claimToken(address(token));
+        allocated = _allocateToken(token);
+    }
+
+    /**
+     * @notice Allocates native ETH received outside `claimNativeFromPons`.
+     */
+    function allocateNative() external nonReentrant returns (uint256 allocated) {
+        allocated = _allocateNative();
+    }
+
+    /**
+     * @notice Allocates ERC-20s received outside `claimTokenFromPons`.
+     */
+    function allocateToken(IERC20 token) external nonReentrant returns (uint256 allocated) {
+        if (address(token) == address(0)) revert ZeroAddress();
+        allocated = _allocateToken(token);
+    }
+
+    /**
+     * @notice Releases all accrued native ETH for either immutable recipient.
+     * Anyone may call this function; the destination cannot be changed.
+     */
+    function releaseNative(address recipient) external nonReentrant returns (uint256 amount) {
+        _requireRecipient(recipient);
+        amount = pendingNative[recipient];
+        if (amount == 0) revert NothingToRelease();
+
+        pendingNative[recipient] = 0;
+        (bool success,) = payable(recipient).call{value: amount}("");
+        if (!success) revert NativeTransferFailed(recipient, amount);
+
+        emit NativeReleased(recipient, amount);
+    }
+
+    /**
+     * @notice Releases all accrued `token` for either immutable recipient.
+     * Anyone may call this function; the destination cannot be changed.
+     */
+    function releaseToken(IERC20 token, address recipient) external nonReentrant returns (uint256 amount) {
+        if (address(token) == address(0)) revert ZeroAddress();
+        _requireRecipient(recipient);
+        amount = pendingToken[address(token)][recipient];
+        if (amount == 0) revert NothingToRelease();
+
+        pendingToken[address(token)][recipient] = 0;
+        token.safeTransfer(recipient, amount);
+
+        emit TokenReleased(address(token), recipient, amount);
+    }
+
+    /**
+     * @notice Directs future pons creator fees for `token` to `newRecipient`.
+     * Existing balances credited to this splitter remain claimable here.
+     */
+    function transferCreatorFeeRecipient(address token, address newRecipient) external onlyController nonReentrant {
+        if (token == address(0) || newRecipient == address(0)) revert ZeroAddress();
+        creatorControls.transferCreatorFeeRecipient(token, newRecipient);
+        emit CreatorFeeRecipientTransferred(token, newRecipient);
+    }
+
+    /**
+     * @notice Enables or disables pons buyback-and-lock for `token`.
+     */
+    function setBuybackEnabled(address token, bool enabled) external onlyController nonReentrant {
+        if (token == address(0)) revert ZeroAddress();
+        creatorControls.setBuybackEnabled(token, enabled);
+        emit BuybackEnabledSet(token, enabled);
+    }
+
+    function _allocateNative() private returns (uint256 amount) {
+        uint256 accounted = pendingNative[recipientOne] + pendingNative[recipientTwo];
+        uint256 balance = address(this).balance;
+        if (balance < accounted) revert AccountingInvariant();
+
+        amount = balance - accounted;
+        if (amount == 0) return 0;
+
+        (uint256 firstAmount, uint256 secondAmount) = _split(amount);
+        pendingNative[recipientOne] += firstAmount;
+        pendingNative[recipientTwo] += secondAmount;
+
+        emit NativeAllocated(amount, firstAmount, secondAmount);
+    }
+
+    function _allocateToken(IERC20 token) private returns (uint256 amount) {
+        uint256 accounted = pendingToken[address(token)][recipientOne] + pendingToken[address(token)][recipientTwo];
+        uint256 balance = token.balanceOf(address(this));
+        if (balance < accounted) revert AccountingInvariant();
+
+        amount = balance - accounted;
+        if (amount == 0) return 0;
+
+        (uint256 firstAmount, uint256 secondAmount) = _split(amount);
+        pendingToken[address(token)][recipientOne] += firstAmount;
+        pendingToken[address(token)][recipientTwo] += secondAmount;
+
+        emit TokenAllocated(address(token), amount, firstAmount, secondAmount);
+    }
+
+    function _split(uint256 amount) private view returns (uint256 firstAmount, uint256 secondAmount) {
+        firstAmount = Math.mulDiv(amount, recipientOneShareBps, BASIS_POINTS);
+        // Assign the indivisible remainder to recipient two so no dust is trapped.
+        secondAmount = amount - firstAmount;
+    }
+
+    function _requireRecipient(address recipient) private view {
+        if (recipient != recipientOne && recipient != recipientTwo) revert UnknownRecipient();
+    }
+
+    function _requireController() private view {
+        if (msg.sender != controller || controller == address(0)) revert NotController();
+    }
+}

--- a/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
+++ b/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
@@ -19,7 +19,8 @@ interface IPonsV2CreatorControls {
  * @title PonsV2TwoWayFeeSplitter
  * @author bananawalnut
  * @notice Optional creator-fee recipient that splits native ETH and ERC-20
- * proceeds between two immutable recipients at an immutable ratio.
+ * proceeds between two immutable recipients at an immutable ratio. Shares are
+ * expressed as whole units out of twenty, where each unit represents 5%.
  *
  * @dev Pons v2 records this contract as `creatorFeeRecipient`. Anyone may
  * claim its accrued balance from the pons fee escrow, allocate direct or
@@ -36,22 +37,27 @@ interface IPonsV2CreatorControls {
 contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    uint16 public constant BASIS_POINTS = 10_000;
+    uint8 public constant SHARE_UNITS = 20;
+    uint8 public constant PERCENT_PER_SHARE_UNIT = 5;
 
     IPonsV2FeeEscrow public immutable feeEscrow;
     IPonsV2CreatorControls public immutable creatorControls;
     address public immutable controller;
     address payable public immutable recipientOne;
     address payable public immutable recipientTwo;
-    uint16 public immutable recipientOneShareBps;
-    uint16 public immutable recipientTwoShareBps;
+    uint8 public immutable recipientOneShareUnits;
+    uint8 public immutable recipientTwoShareUnits;
 
     mapping(address recipient => uint256 amount) public pendingNative;
     mapping(address token => mapping(address recipient => uint256 amount)) public pendingToken;
+    // Fractional numerators carried under SHARE_UNITS so allocation timing
+    // cannot change either recipient's cumulative entitlement.
+    uint256 public nativeRecipientOneRemainder;
+    mapping(address token => uint256 remainder) public tokenRecipientOneRemainder;
 
     error ZeroAddress();
     error DuplicateRecipient();
-    error InvalidShare();
+    error InvalidShareUnits();
     error InvalidControllerConfiguration();
     error NotController();
     error UnknownRecipient();
@@ -75,7 +81,8 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
         IPonsV2FeeEscrow feeEscrow_,
         address payable recipientOne_,
         address payable recipientTwo_,
-        uint16 recipientOneShareBps_,
+        uint8 recipientOneShareUnits_,
+        uint8 recipientTwoShareUnits_,
         IPonsV2CreatorControls creatorControls_,
         address controller_
     ) {
@@ -83,7 +90,10 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
             revert ZeroAddress();
         }
         if (recipientOne_ == recipientTwo_) revert DuplicateRecipient();
-        if (recipientOneShareBps_ == 0 || recipientOneShareBps_ >= BASIS_POINTS) revert InvalidShare();
+        if (
+            recipientOneShareUnits_ == 0 || recipientTwoShareUnits_ == 0
+                || uint16(recipientOneShareUnits_) + uint16(recipientTwoShareUnits_) != SHARE_UNITS
+        ) revert InvalidShareUnits();
 
         bool controlsDisabled = address(creatorControls_) == address(0) && controller_ == address(0);
         bool controlsEnabled = address(creatorControls_) != address(0) && controller_ != address(0);
@@ -92,8 +102,8 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
         feeEscrow = feeEscrow_;
         recipientOne = recipientOne_;
         recipientTwo = recipientTwo_;
-        recipientOneShareBps = recipientOneShareBps_;
-        recipientTwoShareBps = BASIS_POINTS - recipientOneShareBps_;
+        recipientOneShareUnits = recipientOneShareUnits_;
+        recipientTwoShareUnits = recipientTwoShareUnits_;
         creatorControls = creatorControls_;
         controller = controller_;
     }
@@ -193,7 +203,8 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
         amount = balance - accounted;
         if (amount == 0) return 0;
 
-        (uint256 firstAmount, uint256 secondAmount) = _split(amount);
+        (uint256 firstAmount, uint256 secondAmount, uint256 nextRemainder) = _split(amount, nativeRecipientOneRemainder);
+        nativeRecipientOneRemainder = nextRemainder;
         pendingNative[recipientOne] += firstAmount;
         pendingNative[recipientTwo] += secondAmount;
 
@@ -208,16 +219,29 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
         amount = balance - accounted;
         if (amount == 0) return 0;
 
-        (uint256 firstAmount, uint256 secondAmount) = _split(amount);
+        (uint256 firstAmount, uint256 secondAmount, uint256 nextRemainder) =
+            _split(amount, tokenRecipientOneRemainder[address(token)]);
+        tokenRecipientOneRemainder[address(token)] = nextRemainder;
         pendingToken[address(token)][recipientOne] += firstAmount;
         pendingToken[address(token)][recipientTwo] += secondAmount;
 
         emit TokenAllocated(address(token), amount, firstAmount, secondAmount);
     }
 
-    function _split(uint256 amount) private view returns (uint256 firstAmount, uint256 secondAmount) {
-        firstAmount = Math.mulDiv(amount, recipientOneShareBps, BASIS_POINTS);
-        // Assign the indivisible remainder to recipient two so no dust is trapped.
+    function _split(uint256 amount, uint256 previousRemainder)
+        private
+        view
+        returns (uint256 firstAmount, uint256 secondAmount, uint256 nextRemainder)
+    {
+        firstAmount = Math.mulDiv(amount, recipientOneShareUnits, SHARE_UNITS);
+
+        uint256 carriedRemainder = mulmod(amount, recipientOneShareUnits, SHARE_UNITS) + previousRemainder;
+        if (carriedRemainder >= SHARE_UNITS) {
+            firstAmount += 1;
+            carriedRemainder -= SHARE_UNITS;
+        }
+
+        nextRemainder = carriedRemainder;
         secondAmount = amount - firstAmount;
     }
 

--- a/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
+++ b/contractsV2/src/v2/utilities/PonsV2TwoWayFeeSplitter.sol
@@ -27,6 +27,11 @@ interface IPonsV2CreatorControls {
  * forced transfers, and release either recipient's balance. No caller can
  * change the economic terms or redirect the held funds.
  *
+ * ERC-20 releases require exact, stable balance accounting: the splitter
+ * must spend exactly the pending amount and the recipient must receive that
+ * same amount. Fee-on-transfer, rebasing, blocklisting, and other tokens with
+ * mutable or non-standard transfer semantics are not supported.
+ *
  * An optional immutable controller preserves the two actions pons reserves
  * for the current creator fee recipient: transferring future creator fees
  * and enabling or disabling buybacks. Configure both `creatorControls_` and
@@ -57,6 +62,7 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
 
     error ZeroAddress();
     error DuplicateRecipient();
+    error SelfRecipient();
     error InvalidShareUnits();
     error InvalidControllerConfiguration();
     error NotController();
@@ -64,6 +70,9 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
     error NothingToRelease();
     error NativeTransferFailed(address recipient, uint256 amount);
     error AccountingInvariant();
+    error InexactTokenTransfer(
+        address token, address recipient, uint256 expected, uint256 senderSpent, uint256 recipientReceived
+    );
 
     event NativeAllocated(uint256 amount, uint256 recipientOneAmount, uint256 recipientTwoAmount);
     event TokenAllocated(address indexed token, uint256 amount, uint256 recipientOneAmount, uint256 recipientTwoAmount);
@@ -90,6 +99,7 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
             revert ZeroAddress();
         }
         if (recipientOne_ == recipientTwo_) revert DuplicateRecipient();
+        if (recipientOne_ == address(this) || recipientTwo_ == address(this)) revert SelfRecipient();
         if (
             recipientOneShareUnits_ == 0 || recipientTwoShareUnits_ == 0
                 || uint16(recipientOneShareUnits_) + uint16(recipientTwoShareUnits_) != SHARE_UNITS
@@ -170,8 +180,23 @@ contract PonsV2TwoWayFeeSplitter is ReentrancyGuard {
         amount = pendingToken[address(token)][recipient];
         if (amount == 0) revert NothingToRelease();
 
+        uint256 splitterBalanceBefore = token.balanceOf(address(this));
+        uint256 totalPending = pendingToken[address(token)][recipientOne] + pendingToken[address(token)][recipientTwo];
+        if (splitterBalanceBefore < totalPending) revert AccountingInvariant();
+        uint256 recipientBalanceBefore = token.balanceOf(recipient);
+
         pendingToken[address(token)][recipient] = 0;
         token.safeTransfer(recipient, amount);
+
+        uint256 splitterBalanceAfter = token.balanceOf(address(this));
+        uint256 recipientBalanceAfter = token.balanceOf(recipient);
+        uint256 senderSpent =
+            splitterBalanceAfter <= splitterBalanceBefore ? splitterBalanceBefore - splitterBalanceAfter : 0;
+        uint256 recipientReceived =
+            recipientBalanceAfter >= recipientBalanceBefore ? recipientBalanceAfter - recipientBalanceBefore : 0;
+        if (senderSpent != amount || recipientReceived != amount) {
+            revert InexactTokenTransfer(address(token), recipient, amount, senderSpent, recipientReceived);
+        }
 
         emit TokenReleased(address(token), recipient, amount);
     }

--- a/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
+++ b/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
@@ -60,7 +60,7 @@ contract PonsV2TwoWayFeeSplitterTest {
         escrow = new MockPonsV2FeeEscrow();
         controls = new MockPonsV2CreatorControls();
         token = new MockERC20();
-        splitter = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 8_000, address(controls), CONTROLLER);
+        splitter = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 16, 4, address(controls), CONTROLLER);
     }
 
     function testConstructorStoresImmutableTerms() public view {
@@ -69,8 +69,10 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(splitter.controller(), CONTROLLER);
         _assertEq(splitter.recipientOne(), RECIPIENT_ONE);
         _assertEq(splitter.recipientTwo(), RECIPIENT_TWO);
-        _assertEq(splitter.recipientOneShareBps(), 8_000);
-        _assertEq(splitter.recipientTwoShareBps(), 2_000);
+        _assertEq(splitter.SHARE_UNITS(), 20);
+        _assertEq(splitter.PERCENT_PER_SHARE_UNIT(), 5);
+        _assertEq(splitter.recipientOneShareUnits(), 16);
+        _assertEq(splitter.recipientTwoShareUnits(), 4);
     }
 
     function testClaimsAndSplitsNativeFees() public {
@@ -114,20 +116,37 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(token.balanceOf(address(splitter)), 0);
     }
 
-    function testRoundingRemainderAlwaysGoesToRecipientTwo() public {
-        PonsV2TwoWayFeeSplitter thirds = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 3_333, address(0), address(0));
+    function testRemainderCarryMakesTinyAllocationsMatchOneBatch() public {
+        PonsV2TwoWayFeeSplitter batched = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 16, 4, address(0), address(0));
+        PonsV2TwoWayFeeSplitter oneBatch = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 16, 4, address(0), address(0));
 
-        (bool sent,) = address(thirds).call{value: 5}("");
-        require(sent, "native funding failed");
-        thirds.allocateNative();
+        for (uint256 i; i < 5; ++i) {
+            (bool tinySent,) = address(batched).call{value: 1}("");
+            require(tinySent, "native funding failed");
+            batched.allocateNative();
 
-        token.mint(address(thirds), 5);
-        thirds.allocateToken(token);
+            token.mint(address(batched), 1);
+            batched.allocateToken(token);
+        }
 
-        _assertEq(thirds.pendingNative(RECIPIENT_ONE), 1);
-        _assertEq(thirds.pendingNative(RECIPIENT_TWO), 4);
-        _assertEq(thirds.pendingToken(address(token), RECIPIENT_ONE), 1);
-        _assertEq(thirds.pendingToken(address(token), RECIPIENT_TWO), 4);
+        (bool batchSent,) = address(oneBatch).call{value: 5}("");
+        require(batchSent, "native funding failed");
+        oneBatch.allocateNative();
+        token.mint(address(oneBatch), 5);
+        oneBatch.allocateToken(token);
+
+        _assertEq(batched.pendingNative(RECIPIENT_ONE), oneBatch.pendingNative(RECIPIENT_ONE));
+        _assertEq(batched.pendingNative(RECIPIENT_TWO), oneBatch.pendingNative(RECIPIENT_TWO));
+        _assertEq(
+            batched.pendingToken(address(token), RECIPIENT_ONE), oneBatch.pendingToken(address(token), RECIPIENT_ONE)
+        );
+        _assertEq(
+            batched.pendingToken(address(token), RECIPIENT_TWO), oneBatch.pendingToken(address(token), RECIPIENT_TWO)
+        );
+        _assertEq(batched.pendingNative(RECIPIENT_ONE), 4);
+        _assertEq(batched.pendingNative(RECIPIENT_TWO), 1);
+        _assertEq(batched.nativeRecipientOneRemainder(), 0);
+        _assertEq(batched.tokenRecipientOneRemainder(address(token)), 0);
     }
 
     function testDirectTransfersAreAllocatedWithoutPonsClaim() public {
@@ -143,10 +162,12 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(splitter.pendingToken(address(token), RECIPIENT_TWO), 1);
     }
 
-    function testFuzzAllocationConservesNativeAndToken(uint96 rawAmount, uint16 rawShare) public {
+    function testFuzzAllocationConservesNativeAndToken(uint96 rawAmount, uint16 rawFirstShareUnits) public {
         uint256 amount = uint256(rawAmount) + 1;
-        uint16 firstShare = uint16((uint256(rawShare) % 9_999) + 1);
-        PonsV2TwoWayFeeSplitter fuzzed = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, firstShare, address(0), address(0));
+        uint8 firstShareUnits = uint8((uint256(rawFirstShareUnits) % 19) + 1);
+        uint8 secondShareUnits = 20 - firstShareUnits;
+        PonsV2TwoWayFeeSplitter fuzzed =
+            _deploy(RECIPIENT_ONE, RECIPIENT_TWO, firstShareUnits, secondShareUnits, address(0), address(0));
 
         VM.deal(address(this), amount);
         (bool sent,) = address(fuzzed).call{value: amount}("");
@@ -156,7 +177,7 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(fuzzed.allocateNative(), amount);
         _assertEq(fuzzed.allocateToken(token), amount);
 
-        uint256 expectedFirst = (amount * firstShare) / 10_000;
+        uint256 expectedFirst = (amount * firstShareUnits) / 20;
         uint256 expectedSecond = amount - expectedFirst;
         _assertEq(fuzzed.pendingNative(RECIPIENT_ONE), expectedFirst);
         _assertEq(fuzzed.pendingNative(RECIPIENT_TWO), expectedSecond);
@@ -165,10 +186,45 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(expectedFirst + expectedSecond, amount);
     }
 
+    function testFuzzAllocationIsIndependentOfBatching(
+        uint64 rawFirstAmount,
+        uint64 rawSecondAmount,
+        uint8 rawFirstShareUnits
+    ) public {
+        uint256 firstAmount = uint256(rawFirstAmount) + 1;
+        uint256 secondAmount = uint256(rawSecondAmount) + 1;
+        uint256 totalAmount = firstAmount + secondAmount;
+        uint8 firstShareUnits = uint8((uint256(rawFirstShareUnits) % 19) + 1);
+        uint8 secondShareUnits = 20 - firstShareUnits;
+        PonsV2TwoWayFeeSplitter batched =
+            _deploy(RECIPIENT_ONE, RECIPIENT_TWO, firstShareUnits, secondShareUnits, address(0), address(0));
+        PonsV2TwoWayFeeSplitter oneBatch =
+            _deploy(RECIPIENT_ONE, RECIPIENT_TWO, firstShareUnits, secondShareUnits, address(0), address(0));
+
+        VM.deal(address(this), totalAmount * 2);
+
+        _fundAndAllocate(batched, firstAmount);
+        _fundAndAllocate(batched, secondAmount);
+        _fundAndAllocate(oneBatch, totalAmount);
+
+        _assertEq(batched.pendingNative(RECIPIENT_ONE), oneBatch.pendingNative(RECIPIENT_ONE));
+        _assertEq(batched.pendingNative(RECIPIENT_TWO), oneBatch.pendingNative(RECIPIENT_TWO));
+        _assertEq(
+            batched.pendingToken(address(token), RECIPIENT_ONE), oneBatch.pendingToken(address(token), RECIPIENT_ONE)
+        );
+        _assertEq(
+            batched.pendingToken(address(token), RECIPIENT_TWO), oneBatch.pendingToken(address(token), RECIPIENT_TWO)
+        );
+        _assertEq(batched.nativeRecipientOneRemainder(), oneBatch.nativeRecipientOneRemainder());
+        _assertEq(
+            batched.tokenRecipientOneRemainder(address(token)), oneBatch.tokenRecipientOneRemainder(address(token))
+        );
+    }
+
     function testNativeReleaseFailureDoesNotBlockOtherRecipient() public {
         RejectNative rejector = new RejectNative();
         PonsV2TwoWayFeeSplitter rejecting =
-            _deploy(payable(address(rejector)), RECIPIENT_TWO, 5_000, address(0), address(0));
+            _deploy(payable(address(rejector)), RECIPIENT_TWO, 10, 10, address(0), address(0));
         (bool sent,) = address(rejecting).call{value: 10}("");
         require(sent, "native funding failed");
         rejecting.allocateNative();
@@ -201,7 +257,7 @@ contract PonsV2TwoWayFeeSplitterTest {
     function testNativeReleaseCannotBeReentered() public {
         ReentrantNativeRecipient attacker = new ReentrantNativeRecipient();
         PonsV2TwoWayFeeSplitter guarded =
-            _deploy(payable(address(attacker)), RECIPIENT_TWO, 5_000, address(0), address(0));
+            _deploy(payable(address(attacker)), RECIPIENT_TWO, 10, 10, address(0), address(0));
         attacker.setSplitter(guarded);
         (bool sent,) = address(guarded).call{value: 10}("");
         require(sent, "native funding failed");
@@ -236,23 +292,29 @@ contract PonsV2TwoWayFeeSplitterTest {
     }
 
     function testCreatorControlsCanBePermanentlyDisabled() public {
-        PonsV2TwoWayFeeSplitter ownerless = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 5_000, address(0), address(0));
+        PonsV2TwoWayFeeSplitter ownerless = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10, 10, address(0), address(0));
         VM.expectRevert(PonsV2TwoWayFeeSplitter.NotController.selector);
         ownerless.transferCreatorFeeRecipient(LAUNCH_TOKEN, RECIPIENT_TWO);
     }
 
     function testRejectsInvalidConstructorTerms() public {
         VM.expectRevert(PonsV2TwoWayFeeSplitter.DuplicateRecipient.selector);
-        _deploy(RECIPIENT_ONE, RECIPIENT_ONE, 5_000, address(0), address(0));
+        _deploy(RECIPIENT_ONE, RECIPIENT_ONE, 10, 10, address(0), address(0));
 
-        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShare.selector);
-        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 0, address(0), address(0));
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShareUnits.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 0, 20, address(0), address(0));
 
-        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShare.selector);
-        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10_000, address(0), address(0));
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShareUnits.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 20, 0, address(0), address(0));
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShareUnits.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10, 9, address(0), address(0));
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShareUnits.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10, 11, address(0), address(0));
 
         VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidControllerConfiguration.selector);
-        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 5_000, address(controls), address(0));
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10, 10, address(controls), address(0));
     }
 
     function testUnknownRecipientCannotBeReleased() public {
@@ -263,7 +325,8 @@ contract PonsV2TwoWayFeeSplitterTest {
     function _deploy(
         address payable first,
         address payable second,
-        uint16 firstShareBps,
+        uint8 firstShareUnits,
+        uint8 secondShareUnits,
         address creatorControls,
         address controller
     ) private returns (PonsV2TwoWayFeeSplitter deployed) {
@@ -271,10 +334,20 @@ contract PonsV2TwoWayFeeSplitterTest {
             IPonsV2FeeEscrow(address(escrow)),
             first,
             second,
-            firstShareBps,
+            firstShareUnits,
+            secondShareUnits,
             IPonsV2CreatorControls(creatorControls),
             controller
         );
+    }
+
+    function _fundAndAllocate(PonsV2TwoWayFeeSplitter target, uint256 amount) private {
+        (bool sent,) = address(target).call{value: amount}("");
+        require(sent, "native funding failed");
+        target.allocateNative();
+
+        token.mint(address(target), amount);
+        target.allocateToken(token);
     }
 
     function _assertEq(uint256 actual, uint256 expected) private pure {

--- a/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
+++ b/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IPonsV2FeeEscrow} from "../src/v2/interfaces/ILaunchpadV2.sol";
+import {IPonsV2CreatorControls, PonsV2TwoWayFeeSplitter} from "../src/v2/utilities/PonsV2TwoWayFeeSplitter.sol";
+import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockPonsV2CreatorControls} from "./mocks/MockPonsV2CreatorControls.sol";
+import {MockPonsV2FeeEscrow} from "./mocks/MockPonsV2FeeEscrow.sol";
+
+interface Vm {
+    function deal(address account, uint256 newBalance) external;
+    function prank(address sender) external;
+    function expectRevert(bytes4 revertData) external;
+    function expectRevert(bytes calldata revertData) external;
+}
+
+contract RejectNative {
+    receive() external payable {
+        revert("native rejected");
+    }
+}
+
+contract ReentrantNativeRecipient {
+    PonsV2TwoWayFeeSplitter public splitter;
+    bool public attempted;
+    bool public reentrySucceeded;
+
+    function setSplitter(PonsV2TwoWayFeeSplitter splitter_) external {
+        require(address(splitter) == address(0), "splitter already set");
+        splitter = splitter_;
+    }
+
+    receive() external payable {
+        if (!attempted) {
+            attempted = true;
+            (reentrySucceeded,) =
+                address(splitter).call(abi.encodeCall(PonsV2TwoWayFeeSplitter.releaseNative, (address(this))));
+        }
+    }
+}
+
+contract PonsV2TwoWayFeeSplitterTest {
+    Vm private constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    address payable private constant RECIPIENT_ONE = payable(address(0xA11CE));
+    address payable private constant RECIPIENT_TWO = payable(address(0xB0B));
+    address private constant CONTROLLER = address(0xC011EC70);
+    address private constant LAUNCH_TOKEN = address(0x70CE0);
+
+    MockPonsV2FeeEscrow private escrow;
+    MockPonsV2CreatorControls private controls;
+    MockERC20 private token;
+    PonsV2TwoWayFeeSplitter private splitter;
+
+    receive() external payable {}
+
+    function setUp() public {
+        VM.deal(address(this), 100 ether);
+        escrow = new MockPonsV2FeeEscrow();
+        controls = new MockPonsV2CreatorControls();
+        token = new MockERC20();
+        splitter = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 8_000, address(controls), CONTROLLER);
+    }
+
+    function testConstructorStoresImmutableTerms() public view {
+        _assertEq(address(splitter.feeEscrow()), address(escrow));
+        _assertEq(address(splitter.creatorControls()), address(controls));
+        _assertEq(splitter.controller(), CONTROLLER);
+        _assertEq(splitter.recipientOne(), RECIPIENT_ONE);
+        _assertEq(splitter.recipientTwo(), RECIPIENT_TWO);
+        _assertEq(splitter.recipientOneShareBps(), 8_000);
+        _assertEq(splitter.recipientTwoShareBps(), 2_000);
+    }
+
+    function testClaimsAndSplitsNativeFees() public {
+        escrow.credit{value: 1 ether}(address(splitter));
+
+        (uint256 claimed, uint256 allocated) = splitter.claimNativeFromPons();
+
+        _assertEq(claimed, 1 ether);
+        _assertEq(allocated, 1 ether);
+        _assertEq(splitter.pendingNative(RECIPIENT_ONE), 0.8 ether);
+        _assertEq(splitter.pendingNative(RECIPIENT_TWO), 0.2 ether);
+        _assertEq(escrow.balanceOf(address(splitter)), 0);
+
+        uint256 oneBefore = RECIPIENT_ONE.balance;
+        uint256 twoBefore = RECIPIENT_TWO.balance;
+        splitter.releaseNative(RECIPIENT_ONE);
+        splitter.releaseNative(RECIPIENT_TWO);
+
+        _assertEq(RECIPIENT_ONE.balance - oneBefore, 0.8 ether);
+        _assertEq(RECIPIENT_TWO.balance - twoBefore, 0.2 ether);
+        _assertEq(address(splitter).balance, 0);
+    }
+
+    function testClaimsAndSplitsERC20Fees() public {
+        token.mint(address(this), 1_000 ether);
+        token.approve(address(escrow), 1_000 ether);
+        escrow.creditToken(address(splitter), token, 1_000 ether);
+
+        (uint256 claimed, uint256 allocated) = splitter.claimTokenFromPons(token);
+
+        _assertEq(claimed, 1_000 ether);
+        _assertEq(allocated, 1_000 ether);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_ONE), 800 ether);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_TWO), 200 ether);
+
+        splitter.releaseToken(token, RECIPIENT_ONE);
+        splitter.releaseToken(token, RECIPIENT_TWO);
+
+        _assertEq(token.balanceOf(RECIPIENT_ONE), 800 ether);
+        _assertEq(token.balanceOf(RECIPIENT_TWO), 200 ether);
+        _assertEq(token.balanceOf(address(splitter)), 0);
+    }
+
+    function testRoundingRemainderAlwaysGoesToRecipientTwo() public {
+        PonsV2TwoWayFeeSplitter thirds = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 3_333, address(0), address(0));
+
+        (bool sent,) = address(thirds).call{value: 5}("");
+        require(sent, "native funding failed");
+        thirds.allocateNative();
+
+        token.mint(address(thirds), 5);
+        thirds.allocateToken(token);
+
+        _assertEq(thirds.pendingNative(RECIPIENT_ONE), 1);
+        _assertEq(thirds.pendingNative(RECIPIENT_TWO), 4);
+        _assertEq(thirds.pendingToken(address(token), RECIPIENT_ONE), 1);
+        _assertEq(thirds.pendingToken(address(token), RECIPIENT_TWO), 4);
+    }
+
+    function testDirectTransfersAreAllocatedWithoutPonsClaim() public {
+        (bool sent,) = address(splitter).call{value: 5}("");
+        require(sent, "native funding failed");
+        token.mint(address(splitter), 5);
+
+        _assertEq(splitter.allocateNative(), 5);
+        _assertEq(splitter.allocateToken(token), 5);
+        _assertEq(splitter.pendingNative(RECIPIENT_ONE), 4);
+        _assertEq(splitter.pendingNative(RECIPIENT_TWO), 1);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_ONE), 4);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_TWO), 1);
+    }
+
+    function testFuzzAllocationConservesNativeAndToken(uint96 rawAmount, uint16 rawShare) public {
+        uint256 amount = uint256(rawAmount) + 1;
+        uint16 firstShare = uint16((uint256(rawShare) % 9_999) + 1);
+        PonsV2TwoWayFeeSplitter fuzzed = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, firstShare, address(0), address(0));
+
+        VM.deal(address(this), amount);
+        (bool sent,) = address(fuzzed).call{value: amount}("");
+        require(sent, "native funding failed");
+        token.mint(address(fuzzed), amount);
+
+        _assertEq(fuzzed.allocateNative(), amount);
+        _assertEq(fuzzed.allocateToken(token), amount);
+
+        uint256 expectedFirst = (amount * firstShare) / 10_000;
+        uint256 expectedSecond = amount - expectedFirst;
+        _assertEq(fuzzed.pendingNative(RECIPIENT_ONE), expectedFirst);
+        _assertEq(fuzzed.pendingNative(RECIPIENT_TWO), expectedSecond);
+        _assertEq(fuzzed.pendingToken(address(token), RECIPIENT_ONE), expectedFirst);
+        _assertEq(fuzzed.pendingToken(address(token), RECIPIENT_TWO), expectedSecond);
+        _assertEq(expectedFirst + expectedSecond, amount);
+    }
+
+    function testNativeReleaseFailureDoesNotBlockOtherRecipient() public {
+        RejectNative rejector = new RejectNative();
+        PonsV2TwoWayFeeSplitter rejecting =
+            _deploy(payable(address(rejector)), RECIPIENT_TWO, 5_000, address(0), address(0));
+        (bool sent,) = address(rejecting).call{value: 10}("");
+        require(sent, "native funding failed");
+        rejecting.allocateNative();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(PonsV2TwoWayFeeSplitter.NativeTransferFailed.selector, address(rejector), 5)
+        );
+        rejecting.releaseNative(address(rejector));
+
+        _assertEq(rejecting.pendingNative(address(rejector)), 5);
+        uint256 secondBefore = RECIPIENT_TWO.balance;
+        rejecting.releaseNative(RECIPIENT_TWO);
+        _assertEq(RECIPIENT_TWO.balance - secondBefore, 5);
+    }
+
+    function testERC20ReleaseFailurePreservesPendingBalance() public {
+        token.mint(address(splitter), 10);
+        splitter.allocateToken(token);
+        token.setFailTransfers(true);
+
+        VM.expectRevert(abi.encodeWithSelector(SafeERC20.SafeERC20FailedOperation.selector, address(token)));
+        splitter.releaseToken(token, RECIPIENT_ONE);
+
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_ONE), 8);
+        token.setFailTransfers(false);
+        splitter.releaseToken(token, RECIPIENT_ONE);
+        _assertEq(token.balanceOf(RECIPIENT_ONE), 8);
+    }
+
+    function testNativeReleaseCannotBeReentered() public {
+        ReentrantNativeRecipient attacker = new ReentrantNativeRecipient();
+        PonsV2TwoWayFeeSplitter guarded =
+            _deploy(payable(address(attacker)), RECIPIENT_TWO, 5_000, address(0), address(0));
+        attacker.setSplitter(guarded);
+        (bool sent,) = address(guarded).call{value: 10}("");
+        require(sent, "native funding failed");
+        guarded.allocateNative();
+
+        guarded.releaseNative(address(attacker));
+
+        require(attacker.attempted(), "reentry was not attempted");
+        require(!attacker.reentrySucceeded(), "reentry unexpectedly succeeded");
+        _assertEq(address(attacker).balance, 5);
+        _assertEq(guarded.pendingNative(address(attacker)), 0);
+        _assertEq(guarded.pendingNative(RECIPIENT_TWO), 5);
+    }
+
+    function testControllerCanForwardOnlyPonsCreatorControls() public {
+        VM.prank(CONTROLLER);
+        splitter.transferCreatorFeeRecipient(LAUNCH_TOKEN, RECIPIENT_TWO);
+        _assertEq(controls.lastCaller(), address(splitter));
+        _assertEq(controls.lastToken(), LAUNCH_TOKEN);
+        _assertEq(controls.lastRecipient(), RECIPIENT_TWO);
+
+        VM.prank(CONTROLLER);
+        splitter.setBuybackEnabled(LAUNCH_TOKEN, true);
+        _assertEq(controls.lastCaller(), address(splitter));
+        _assertEq(controls.lastToken(), LAUNCH_TOKEN);
+        require(controls.lastBuybackEnabled(), "buyback flag not forwarded");
+    }
+
+    function testNonControllerCannotForwardCreatorControls() public {
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.NotController.selector);
+        splitter.setBuybackEnabled(LAUNCH_TOKEN, true);
+    }
+
+    function testCreatorControlsCanBePermanentlyDisabled() public {
+        PonsV2TwoWayFeeSplitter ownerless = _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 5_000, address(0), address(0));
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.NotController.selector);
+        ownerless.transferCreatorFeeRecipient(LAUNCH_TOKEN, RECIPIENT_TWO);
+    }
+
+    function testRejectsInvalidConstructorTerms() public {
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.DuplicateRecipient.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_ONE, 5_000, address(0), address(0));
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShare.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 0, address(0), address(0));
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidShare.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10_000, address(0), address(0));
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidControllerConfiguration.selector);
+        _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 5_000, address(controls), address(0));
+    }
+
+    function testUnknownRecipientCannotBeReleased() public {
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.UnknownRecipient.selector);
+        splitter.releaseNative(address(0xBAD));
+    }
+
+    function _deploy(
+        address payable first,
+        address payable second,
+        uint16 firstShareBps,
+        address creatorControls,
+        address controller
+    ) private returns (PonsV2TwoWayFeeSplitter deployed) {
+        deployed = new PonsV2TwoWayFeeSplitter(
+            IPonsV2FeeEscrow(address(escrow)),
+            first,
+            second,
+            firstShareBps,
+            IPonsV2CreatorControls(creatorControls),
+            controller
+        );
+    }
+
+    function _assertEq(uint256 actual, uint256 expected) private pure {
+        require(actual == expected, "uint mismatch");
+    }
+
+    function _assertEq(address actual, address expected) private pure {
+        require(actual == expected, "address mismatch");
+    }
+}

--- a/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
+++ b/contractsV2/test/PonsV2TwoWayFeeSplitter.t.sol
@@ -5,6 +5,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {IPonsV2FeeEscrow} from "../src/v2/interfaces/ILaunchpadV2.sol";
 import {IPonsV2CreatorControls, PonsV2TwoWayFeeSplitter} from "../src/v2/utilities/PonsV2TwoWayFeeSplitter.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
+import {MockFeeOnTransferERC20} from "./mocks/MockFeeOnTransferERC20.sol";
 import {MockPonsV2CreatorControls} from "./mocks/MockPonsV2CreatorControls.sol";
 import {MockPonsV2FeeEscrow} from "./mocks/MockPonsV2FeeEscrow.sol";
 
@@ -37,6 +38,26 @@ contract ReentrantNativeRecipient {
             (reentrySucceeded,) =
                 address(splitter).call(abi.encodeCall(PonsV2TwoWayFeeSplitter.releaseNative, (address(this))));
         }
+    }
+}
+
+contract SelfRecipientFactory {
+    function deploy(IPonsV2FeeEscrow feeEscrow, address payable otherRecipient, bool selfIsRecipientOne)
+        external
+        returns (PonsV2TwoWayFeeSplitter)
+    {
+        address payable predictedSplitter = payable(nextCreateAddress());
+        address payable first = selfIsRecipientOne ? predictedSplitter : otherRecipient;
+        address payable second = selfIsRecipientOne ? otherRecipient : predictedSplitter;
+
+        return
+            new PonsV2TwoWayFeeSplitter(
+                feeEscrow, first, second, 10, 10, IPonsV2CreatorControls(address(0)), address(0)
+            );
+    }
+
+    function nextCreateAddress() public view returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(hex"d694", address(this), hex"01")))));
     }
 }
 
@@ -254,6 +275,44 @@ contract PonsV2TwoWayFeeSplitterTest {
         _assertEq(token.balanceOf(RECIPIENT_ONE), 8);
     }
 
+    function testRejectsFeeOnTransferTokenWithoutChangingAccounting() public {
+        MockFeeOnTransferERC20 feeToken = new MockFeeOnTransferERC20();
+        feeToken.mint(address(splitter), 100);
+        splitter.allocateToken(feeToken);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                PonsV2TwoWayFeeSplitter.InexactTokenTransfer.selector, address(feeToken), RECIPIENT_ONE, 80, 80, 72
+            )
+        );
+        splitter.releaseToken(feeToken, RECIPIENT_ONE);
+
+        _assertEq(feeToken.balanceOf(address(splitter)), 100);
+        _assertEq(feeToken.balanceOf(RECIPIENT_ONE), 0);
+        _assertEq(splitter.pendingToken(address(feeToken), RECIPIENT_ONE), 80);
+        _assertEq(splitter.pendingToken(address(feeToken), RECIPIENT_TWO), 20);
+    }
+
+    function testUndercollateralizedTokenBlocksEveryReleaseUntilRestored() public {
+        token.mint(address(splitter), 100);
+        splitter.allocateToken(token);
+        token.burn(address(splitter), 1);
+
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.AccountingInvariant.selector);
+        splitter.releaseToken(token, RECIPIENT_ONE);
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.AccountingInvariant.selector);
+        splitter.releaseToken(token, RECIPIENT_TWO);
+
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_ONE), 80);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_TWO), 20);
+
+        token.mint(address(splitter), 1);
+        splitter.releaseToken(token, RECIPIENT_ONE);
+        splitter.releaseToken(token, RECIPIENT_TWO);
+        _assertEq(token.balanceOf(RECIPIENT_ONE), 80);
+        _assertEq(token.balanceOf(RECIPIENT_TWO), 20);
+    }
+
     function testNativeReleaseCannotBeReentered() public {
         ReentrantNativeRecipient attacker = new ReentrantNativeRecipient();
         PonsV2TwoWayFeeSplitter guarded =
@@ -315,6 +374,16 @@ contract PonsV2TwoWayFeeSplitterTest {
 
         VM.expectRevert(PonsV2TwoWayFeeSplitter.InvalidControllerConfiguration.selector);
         _deploy(RECIPIENT_ONE, RECIPIENT_TWO, 10, 10, address(controls), address(0));
+    }
+
+    function testRejectsPredictedSplitterAsEitherRecipient() public {
+        SelfRecipientFactory firstFactory = new SelfRecipientFactory();
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.SelfRecipient.selector);
+        firstFactory.deploy(IPonsV2FeeEscrow(address(escrow)), RECIPIENT_TWO, true);
+
+        SelfRecipientFactory secondFactory = new SelfRecipientFactory();
+        VM.expectRevert(PonsV2TwoWayFeeSplitter.SelfRecipient.selector);
+        secondFactory.deploy(IPonsV2FeeEscrow(address(escrow)), RECIPIENT_ONE, false);
     }
 
     function testUnknownRecipientCannotBeReleased() public {

--- a/contractsV2/test/integration/PonsV2TwoWayFeeSplitterFork.t.sol
+++ b/contractsV2/test/integration/PonsV2TwoWayFeeSplitterFork.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IPonsV2FeeEscrow} from "../../src/v2/interfaces/ILaunchpadV2.sol";
+import {IPonsV2CreatorControls, PonsV2TwoWayFeeSplitter} from "../../src/v2/utilities/PonsV2TwoWayFeeSplitter.sol";
+import {MockERC20} from "../mocks/MockERC20.sol";
+
+interface VmFork {
+    function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
+    function deal(address account, uint256 newBalance) external;
+    function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
+    function skip(bool skipTest) external;
+}
+
+interface IPonsV2LaunchFactoryFork {
+    function feeEscrow() external view returns (IPonsV2FeeEscrow);
+}
+
+contract PonsV2TwoWayFeeSplitterForkTest {
+    VmFork private constant VM = VmFork(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    address private constant PONS_V2_FACTORY = 0x7eD598BcEf8bd9Edd8C97A195C6d13f40801EC7e;
+    address private constant PONS_V2_FEE_ESCROW = 0xd3AFEB2a57f70eF218Aa82451c51B2fb0416Ac9e;
+    address payable private constant RECIPIENT_ONE = payable(address(0xA11CE));
+    address payable private constant RECIPIENT_TWO = payable(address(0xB0B));
+
+    function testForkClaimsAndReleasesNativeThroughDeployedEscrow() public {
+        IPonsV2FeeEscrow escrow = _selectRobinhoodFork();
+        PonsV2TwoWayFeeSplitter splitter = _deploy(escrow);
+        VM.deal(address(this), 5);
+
+        escrow.credit{value: 5}(address(splitter));
+        (uint256 claimed, uint256 allocated) = splitter.claimNativeFromPons();
+
+        _assertEq(claimed, 5);
+        _assertEq(allocated, 5);
+        _assertEq(splitter.pendingNative(RECIPIENT_ONE), 4);
+        _assertEq(splitter.pendingNative(RECIPIENT_TWO), 1);
+
+        uint256 firstBefore = RECIPIENT_ONE.balance;
+        uint256 secondBefore = RECIPIENT_TWO.balance;
+        splitter.releaseNative(RECIPIENT_ONE);
+        splitter.releaseNative(RECIPIENT_TWO);
+        _assertEq(RECIPIENT_ONE.balance - firstBefore, 4);
+        _assertEq(RECIPIENT_TWO.balance - secondBefore, 1);
+    }
+
+    function testForkClaimsAndReleasesERC20ThroughDeployedEscrow() public {
+        IPonsV2FeeEscrow escrow = _selectRobinhoodFork();
+        PonsV2TwoWayFeeSplitter splitter = _deploy(escrow);
+        MockERC20 token = new MockERC20();
+        token.mint(address(this), 5);
+        token.approve(address(escrow), 5);
+
+        escrow.creditToken(address(splitter), address(token), 5);
+        (uint256 claimed, uint256 allocated) = splitter.claimTokenFromPons(token);
+
+        _assertEq(claimed, 5);
+        _assertEq(allocated, 5);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_ONE), 4);
+        _assertEq(splitter.pendingToken(address(token), RECIPIENT_TWO), 1);
+
+        splitter.releaseToken(token, RECIPIENT_ONE);
+        splitter.releaseToken(token, RECIPIENT_TWO);
+        _assertEq(token.balanceOf(RECIPIENT_ONE), 4);
+        _assertEq(token.balanceOf(RECIPIENT_TWO), 1);
+    }
+
+    function _selectRobinhoodFork() private returns (IPonsV2FeeEscrow escrow) {
+        string memory rpcUrl = VM.envOr("ROBINHOOD_RPC_URL", string(""));
+        if (bytes(rpcUrl).length == 0) VM.skip(true);
+
+        VM.createSelectFork(rpcUrl);
+        require(block.chainid == 4663, "unexpected chain");
+        require(PONS_V2_FACTORY.code.length != 0, "factory not deployed");
+
+        escrow = IPonsV2LaunchFactoryFork(PONS_V2_FACTORY).feeEscrow();
+        _assertEq(address(escrow), PONS_V2_FEE_ESCROW);
+        require(address(escrow).code.length != 0, "escrow not deployed");
+    }
+
+    function _deploy(IPonsV2FeeEscrow escrow) private returns (PonsV2TwoWayFeeSplitter) {
+        return new PonsV2TwoWayFeeSplitter(
+            escrow, RECIPIENT_ONE, RECIPIENT_TWO, 16, 4, IPonsV2CreatorControls(address(0)), address(0)
+        );
+    }
+
+    function _assertEq(uint256 actual, uint256 expected) private pure {
+        require(actual == expected, "uint mismatch");
+    }
+
+    function _assertEq(address actual, address expected) private pure {
+        require(actual == expected, "address mismatch");
+    }
+}

--- a/contractsV2/test/mocks/MockERC20.sol
+++ b/contractsV2/test/mocks/MockERC20.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    bool public failTransfers;
+
+    constructor() ERC20("Mock Token", "MOCK") {}
+
+    function mint(address recipient, uint256 amount) external {
+        _mint(recipient, amount);
+    }
+
+    function setFailTransfers(bool failTransfers_) external {
+        failTransfers = failTransfers_;
+    }
+
+    function transfer(address recipient, uint256 amount) public override returns (bool) {
+        if (failTransfers) return false;
+        return super.transfer(recipient, amount);
+    }
+
+    function transferFrom(address sender, address recipient, uint256 amount) public override returns (bool) {
+        if (failTransfers) return false;
+        return super.transferFrom(sender, recipient, amount);
+    }
+}

--- a/contractsV2/test/mocks/MockERC20.sol
+++ b/contractsV2/test/mocks/MockERC20.sol
@@ -12,6 +12,10 @@ contract MockERC20 is ERC20 {
         _mint(recipient, amount);
     }
 
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+
     function setFailTransfers(bool failTransfers_) external {
         failTransfers = failTransfers_;
     }

--- a/contractsV2/test/mocks/MockFeeOnTransferERC20.sol
+++ b/contractsV2/test/mocks/MockFeeOnTransferERC20.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockFeeOnTransferERC20 is ERC20 {
+    constructor() ERC20("Fee-on-transfer Token", "FEE") {}
+
+    function mint(address recipient, uint256 amount) external {
+        _mint(recipient, amount);
+    }
+
+    function _update(address from, address to, uint256 amount) internal override {
+        if (from != address(0) && to != address(0)) {
+            uint256 fee = amount / 10;
+            if (fee != 0) super._update(from, address(0), fee);
+            super._update(from, to, amount - fee);
+            return;
+        }
+
+        super._update(from, to, amount);
+    }
+}

--- a/contractsV2/test/mocks/MockPonsV2CreatorControls.sol
+++ b/contractsV2/test/mocks/MockPonsV2CreatorControls.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+contract MockPonsV2CreatorControls {
+    address public lastCaller;
+    address public lastToken;
+    address public lastRecipient;
+    bool public lastBuybackEnabled;
+
+    function transferCreatorFeeRecipient(address token, address newRecipient) external {
+        lastCaller = msg.sender;
+        lastToken = token;
+        lastRecipient = newRecipient;
+    }
+
+    function setBuybackEnabled(address token, bool enabled) external {
+        lastCaller = msg.sender;
+        lastToken = token;
+        lastBuybackEnabled = enabled;
+    }
+}

--- a/contractsV2/test/mocks/MockPonsV2FeeEscrow.sol
+++ b/contractsV2/test/mocks/MockPonsV2FeeEscrow.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract MockPonsV2FeeEscrow {
+    using SafeERC20 for IERC20;
+
+    mapping(address recipient => uint256 amount) public balanceOf;
+    mapping(address recipient => mapping(address token => uint256 amount)) public balanceOfToken;
+
+    function credit(address recipient) external payable {
+        balanceOf[recipient] += msg.value;
+    }
+
+    function creditToken(address recipient, IERC20 token, uint256 amount) external {
+        token.safeTransferFrom(msg.sender, address(this), amount);
+        balanceOfToken[recipient][address(token)] += amount;
+    }
+
+    function claim() external returns (uint256 amount) {
+        amount = _claimNative(msg.sender, balanceOf[msg.sender]);
+    }
+
+    function claim(uint256 amount) external returns (uint256) {
+        return _claimNative(msg.sender, amount);
+    }
+
+    function claimToken(address token) external returns (uint256 amount) {
+        amount = _claimToken(msg.sender, IERC20(token), balanceOfToken[msg.sender][token]);
+    }
+
+    function claimToken(address token, uint256 amount) external returns (uint256) {
+        return _claimToken(msg.sender, IERC20(token), amount);
+    }
+
+    function _claimNative(address recipient, uint256 amount) private returns (uint256) {
+        require(balanceOf[recipient] >= amount, "insufficient native credit");
+        balanceOf[recipient] -= amount;
+        (bool success,) = payable(recipient).call{value: amount}("");
+        require(success, "native claim failed");
+        return amount;
+    }
+
+    function _claimToken(address recipient, IERC20 token, uint256 amount) private returns (uint256) {
+        require(balanceOfToken[recipient][address(token)] >= amount, "insufficient token credit");
+        balanceOfToken[recipient][address(token)] -= amount;
+        token.safeTransfer(recipient, amount);
+        return amount;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an optional `PonsV2TwoWayFeeSplitter` utility for native ETH and standard ERC-20 creator proceeds.
- Makes both recipients and their share units immutable.
- Accepts two non-zero integer shares that must add to 20; each unit represents 5%, allowing splits from 5%/95% through 95%/5%.
- Rejects either recipient when it equals the splitter itself, including a predicted deployment address.
- Carries fractional remainders across allocations so transaction batching cannot change either recipient's cumulative entitlement.
- Requires exact ERC-20 sender and recipient balance deltas, preserves pending accounting on failure, and blocks all releases while pending balances are undercollateralized.
- Uses pons's existing `IPonsV2FeeEscrow` interface plus OpenZeppelin `SafeERC20`, `Math.mulDiv`, and `ReentrancyGuard`.
- Releases each recipient independently so a failed native transfer cannot block the other recipient.
- Optionally preserves pons's two creator-only controls behind one immutable, narrowly scoped controller.
- Documents deployment, claiming, token assumptions, `creatorFeeRecipient` launch integration, and Robinhood Chain fork verification.

## ERC-20 safety model

The splitter supports ERC-20s with exact, stable transfer accounting. Fee-on-transfer, rebasing, blocklisting, and otherwise mutable or non-standard token behavior is unsupported. A release reverts unless the splitter spends exactly the pending amount and the recipient receives exactly that amount. If the splitter's balance falls below total pending, every release remains blocked until backing is restored so release order cannot assign a loss to one recipient.

## Creator-control model

The splitter has no owner and no mutable administration. Deployments choose one of two permanent modes:

1. Set both `creatorControls` and `controller` to zero, permanently forfeiting the ability to transfer future creator fees or toggle buybacks through the splitter; or
2. Set both values, allowing only the immutable controller to forward `transferCreatorFeeRecipient` and `setBuybackEnabled` to the pons factory.

The controller cannot change either recipient, the split ratio, accrued balances, or itself. Transferring the pons creator-fee recipient affects future fees only; balances already credited to the splitter remain claimable and keep the immutable split.

## Validation

From `contractsV2/`:

```sh
forge test --offline --fuzz-runs 10000 -vv
forge lint --offline
forge build --offline --sizes
forge coverage --offline --report summary
ROBINHOOD_RPC_URL=https://rpc.mainnet.chain.robinhood.com forge test --match-contract PonsV2TwoWayFeeSplitterForkTest -vv
```

The suite contains 18 passing unit tests, with both fuzz properties run for 10,000 cases. It includes exploit regression tests for predicted self-recipients, fee-on-transfer tokens, negative-rebase undercollateralization, failed transfers, reentrancy, share conservation, batching independence, controller authorization, and invalid constructor terms.

Two additional tests pass on a local fork of Robinhood Chain (chain ID 4663), exercising native ETH and ERC-20 credit, claim, split, and release through the deployed pons v2 fee escrow. The fork tests broadcast no transactions and skip when `ROBINHOOD_RPC_URL` is unset.

The splitter has 99.03% line coverage and a 5,833-byte optimized runtime with Solidity 0.8.26, optimizer 200, and Cancun EVM target.

Scope note: the repository's full V2 source tree has a pre-existing `exemptFromSnipeTax` compile error outside this isolated utility profile. This PR does not alter that unrelated factory/curve source mismatch.

## Provenance

- Author: `bananawalnut`
- Upstream base: `8b9bf371030279133017b5c1b713823f5889c5d2`
- Current head: `25c96467ec061393022edb987f11c93b1c7746e6`